### PR TITLE
ルーティング: Editor 用の root /editor /pre_codes/:id/body を追加（スタブ実装込）

### DIFF
--- a/app/controllers/editor_controller.rb
+++ b/app/controllers/editor_controller.rb
@@ -1,0 +1,14 @@
+# app/controllers/editor_controller.rb
+class EditorController < ApplicationController
+  def index
+    head :ok
+  end
+
+  def create
+    head :ok
+  end
+
+  def pre_code_body
+    render json: { id: params[:id].to_i, title: "stub", body: "" }
+  end
+end

--- a/app/helpers/editor_helper.rb
+++ b/app/helpers/editor_helper.rb
@@ -1,0 +1,2 @@
+module EditorHelper
+end

--- a/app/views/editor/index.html.erb
+++ b/app/views/editor/index.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Editor#index</h1>
+  <p>Find me in app/views/editor/index.html.erb</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,10 +21,16 @@ Rails.application.routes.draw do
 
   # Code Library機能
   resources :code_libraries, only: %i[index show], concerns: :paginatable
-
-  # 非同期用（シンプルな REST）
   resources :likes,      only: %i[create destroy]
   resources :used_codes, only: %i[create]
+
+  # Code Editor
+  # root "editor#index"
+  resource :editor, only: %i[index create]
+  get "/pre_codes/:id/body",
+      to: "editor#pre_code_body",
+      as: :pre_code_body,
+      constraints: { id: /\d+/ }
 
   # OmniAuth
   get "/auth/:provider", to: "omni_auth#passthru", as: :auth,

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Editors", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/editor/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
### 概要
Editor 用の root /editor /pre_codes/:id/body を作成した。

**作業内容**

- ブランチ（feature/code_editor）を作成した
- config/routes.rb にEditor 用の root /editor /pre_codes/:id/body を追加した
- EditorController を仮で作成し、ルートを通した