### PR TITLE
ルートエラーの修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # config/routes.rb
 Rails.application.routes.draw do
   get "tests/index"
-  root "tests#index"
 
   # Render のヘルスチェック用
   get "up" => "rails/health#show", as: :rails_health_check
@@ -25,8 +24,9 @@ Rails.application.routes.draw do
   resources :used_codes, only: %i[create]
 
   # Code Editor
-  # root "editor#index"
-  resource :editor, only: %i[index create]
+  root "editor#index"
+  get  "/editor", to: "editor#index",  as: :editor
+  post "/editor", to: "editor#create"
   get "/pre_codes/:id/body",
       to: "editor#pre_code_body",
       as: :pre_code_body,

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -1,10 +1,14 @@
-require 'rails_helper'
+# spec/requests/editor_routes_spec.rb
+require "rails_helper"
 
-RSpec.describe "Editors", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/editor/index"
-      expect(response).to have_http_status(:success)
-    end
+RSpec.describe "Editor routing", type: :request do
+  it "GET / returns 200" do
+    get root_path
+    expect(response).to have_http_status(:ok).or have_http_status(:no_content)
+  end
+
+  it "GET /pre_codes/:id/body returns 200" do
+    get pre_code_body_path(1)
+    expect(response).to have_http_status(:ok)
   end
 end


### PR DESCRIPTION
### 概要
ルートエラーが発生したので、その修正を行った。

**作業内容**

以下のコードの変更前のように、resource（単数系）で、indexを定義してしまっていた。
そのため、getsやpostを使ったルート指定に変更した。

```ruby
# 変更前
resource :editor, only: %i[index create] 

# 変更後
  get  "/editor", to: "editor#index",  as: :editor
  post "/editor", to: "editor#create"
``` 