### PR TITLE
feat(editor): httparty/dotenv導入（.env準備・Judge0設定）＋ImportmapでCodeMirror…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# URL 生成用
+APP_HOST=yourapp.onrender.com
+
+# SMTP（使うサービスに合わせて）
+SMTP_ADDRESS=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_DOMAIN=yourdomain.com
+SMTP_USERNAME=apikey      # SendGrid の例
+SMTP_PASSWORD=************
+
+JUDGE0_BASE_URL=
+JUDGE0_RAPIDAPI_KEY=
+JUDGE0_HOST_HEADER=

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "ransack"
 # 開発支援
 gem "dotenv-rails", groups: %i[development test]     # 環境変数を .env で
 
+# HTTPクライアント
+gem "httparty"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -132,6 +133,10 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.2)
@@ -470,6 +475,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  httparty
   importmap-rails
   kamal
   kaminari

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,7 +1,30 @@
-# Pin npm packages by running ./bin/importmap
+# config/importmap.rb
 
+# 基本アプリ（エントリポイント）
 pin "application"
-pin "@hotwired/turbo-rails", to: "turbo.min.js"
-pin "@hotwired/stimulus", to: "stimulus.min.js"
+
+# Hotwire（Turbo & Stimulus）
+pin "@hotwired/turbo-rails",   to: "turbo.min.js"
+pin "@hotwired/stimulus",      to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+
+# Stimulus コントローラを一括で読み込み
 pin_all_from "app/javascript/controllers", under: "controllers"
+
+# ----- axios（HTTP 通信ライブラリ） -----
+pin "axios", to: "https://cdn.jsdelivr.net/npm/axios@1.7.2/+esm"
+
+# ----- CodeMirror 6 minimal set -----
+# 状態管理
+pin "@codemirror/state",  to: "https://esm.sh/@codemirror/state@6"
+# エディタビュー（本体 UI）
+pin "@codemirror/view",   to: "https://esm.sh/@codemirror/view@6"
+# 言語共通レイヤ（高ライト/言語基盤）
+pin "@codemirror/language", to: "https://esm.sh/@codemirror/language@6"
+# JavaScript サポート
+pin "@codemirror/lang-javascript", to: "https://esm.sh/@codemirror/lang-javascript@6"
+# Ruby（CM6 公式パッケージは未提供のため、CM5 の legacy-modes を利用）
+pin "@codemirror/legacy-modes/ruby", to: "https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/ruby/ruby.js"
+
+# ダークテーマ
+pin "@codemirror/theme-one-dark", to: "https://esm.sh/@codemirror/theme-one-dark@6"

--- a/config/initializers/judge0.rb
+++ b/config/initializers/judge0.rb
@@ -1,0 +1,7 @@
+Rails.application.configure do
+  config.x.judge0 = {
+    base_url: ENV["JUDGE0_BASE_URL"],
+    api_key:  ENV["JUDGE0_RAPIDAPI_KEY"],
+    host_hdr: ENV["JUDGE0_HOST_HEADER"]
+  }
+end


### PR DESCRIPTION
### 概要
Gemの導入とImportmapでCodeMirror/axiosをCDNピンした。

**作業内容**

- 必要gem（gem "httparty"）を導入した。
- .env / .env.example の編集を行った
- config/initializers/judge0.rb の作成と編集
- 手動で動作チェック（.env準備・Judge0設定）
- config/importmap.rb でピンを追加
- 手動で動作チェック（CDN）