### PR TITLE
リモート環境でのRSpecエラーの修繕

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,10 @@ jobs:
       DB_HOST: 127.0.0.1
       DB_USER: postgres
       DB_PASSWORD: postgres
-      # DATABASE_URL を使う場合は上の PG* を消してこちらを使ってもOK
-      # DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      # Judge0 API 環境変数
+      JUDGE0_BASE_URL: https://judge0-ce.p.rapidapi.com
+      JUDGE0_RAPIDAPI_KEY: ${{ secrets.JUDGE0_RAPIDAPI_KEY }}
+      JUDGE0_HOST_HEADER: judge0-ce.p.rapidapi.com
 
     steps:
       - name: Install system packages


### PR DESCRIPTION
### 概要
GitHub内で実行した際に起きたRSpecエラーの修繕

**作業内容**

- judge0 APIの環境変数がリモートだと定義されてなかったのが原因
- .github/workflows/ci.ymlに環境変数（見られても問題ないものだけ）を定義した