### PR TITLE
セキュリティ: AxiosにCSRFトークンを自動付与しJSON POSTを安全に実行できるように設定

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,24 @@
-// app/javascript/application.js
 import "@hotwired/turbo-rails"
 import "controllers"
+
+// HTTP 通信ライブラリ axios を利用
 import axios from "axios"
 
-const token = document.querySelector('meta[name="csrf-token"]')?.content
-if (token) axios.defaults.headers.common["X-CSRF-Token"] = token
+// ===============================
+// CSRF対策 & JSONリクエスト設定
+// ===============================
+
+// Railsが出力するCSRFトークンを <meta> タグから取得
+const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content")
+
+// CSRFトークンが存在する場合、axiosの共通ヘッダに追加
+if (token) {
+  axios.defaults.headers.common["X-CSRF-Token"] = token
+}
+
+// Railsが期待するリクエスト種別を明示
+axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest"
+
+// JSON形式で送受信することを明示
+axios.defaults.headers.common["Content-Type"] = "application/json"
+axios.defaults.headers.common["Accept"] = "application/json"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,4 @@
+Rails.application.config.session_store :cookie_store,
+  key: "_railslearningtest_session",              # アプリごとにユニークな名前に
+  same_site: :lax,                      # デフォルト値だが明示しておく
+  secure: Rails.env.production?         # 本番は HTTPS のみ送信

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Editor API", type: :request do
     let!(:pc)  { create(:pre_code, user:, title: "t", body: "p 'hi'") }
 
     it "対象の body を返す" do
-      get pre_code_body_path(pc.id)
+      get pre_code_body_path(pc.id), as: :json
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
       expect(json["id"]).to eq(pc.id)
@@ -57,7 +57,7 @@ RSpec.describe "Editor API", type: :request do
     end
 
     it "存在しない id は 404" do
-      get pre_code_body_path(999_999)
+      get pre_code_body_path(999_999), as: :json
       expect(response).to have_http_status(:not_found)
       expect(JSON.parse(response.body)).to include("error")
     end


### PR DESCRIPTION
### 概要
AxiosにCSRFトークンを自動付与し、JSON POSTを安全に実行できるように設定した。

**作業内容**

- app/javascript/application.js で、CSRF対策 & JSONリクエスト設定を行った
- app/controllers/editor_controller.rb で、JSON以外は弾く（明示的に 406 を返す）設定を作成した
- config/initializers/session_store.rb を作成し、セッション Cookie の安全属性を明示化した
- 実装内容が正確に実装されているか手動でチェックを行った