### PR TITLE
feat(editor): Books/BookSections のモデル・マイグレーション追加（制約/複合INDEX・前後ページAPI・…

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,0 +1,7 @@
+# app/models/book.rb
+class Book < ApplicationRecord
+  has_many :book_sections, -> { order(:position) }, dependent: :destroy
+
+  validates :title,       presence: true, length: { maximum: 100 }
+  validates :description, presence: true, length: { maximum: 500 }
+end

--- a/app/models/book_section.rb
+++ b/app/models/book_section.rb
@@ -1,0 +1,20 @@
+# app/models/book_section.rb
+class BookSection < ApplicationRecord
+  belongs_to :book
+  has_many_attached :images
+
+  validates :heading,  presence: true, length: { maximum: 100 }
+  validates :content,  presence: true
+  validates :position, presence: true,
+                       numericality: { only_integer: true, greater_than_or_equal_to: 0 },
+                       uniqueness: { scope: :book_id }
+
+  # 同一Book内での前後ページ
+  def previous
+    book.book_sections.where("position < ?", position).order(position: :desc).first
+  end
+
+  def next
+    book.book_sections.where("position > ?", position).order(position: :asc).first
+  end
+end

--- a/db/migrate/20250822182515_create_books.rb
+++ b/db/migrate/20250822182515_create_books.rb
@@ -1,0 +1,9 @@
+class CreateBooks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :books do |t|
+      t.string :title,       null: false
+      t.text   :description, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250822182525_create_book_sections.rb
+++ b/db/migrate/20250822182525_create_book_sections.rb
@@ -1,0 +1,15 @@
+class CreateBookSections < ActiveRecord::Migration[8.0]
+  def change
+    create_table :book_sections do |t|
+      t.references :book, null: false, foreign_key: true, index: true
+      t.string  :heading,  null: false
+      t.text    :content,  null: false
+      t.boolean :is_free,  null: false, default: false
+      t.integer :position, null: false
+      t.timestamps
+    end
+
+    # 同一Book内で position は一意
+    add_index :book_sections, %i[book_id position], unique: true
+  end
+end

--- a/db/migrate/20250822182647_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250822182647_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,56 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_20_133536) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_22_182647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "book_sections", force: :cascade do |t|
+    t.bigint "book_id", null: false
+    t.string "heading", null: false
+    t.text "content", null: false
+    t.boolean "is_free", default: false, null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["book_id", "position"], name: "index_book_sections_on_book_id_and_position", unique: true
+    t.index ["book_id"], name: "index_book_sections_on_book_id"
+  end
+
+  create_table "books", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -65,6 +112,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_133536) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token_unique", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "book_sections", "books"
   add_foreign_key "likes", "pre_codes"
   add_foreign_key "likes", "users"
   add_foreign_key "pre_codes", "users"

--- a/spec/factories/book_sections.rb
+++ b/spec/factories/book_sections.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :book_section do
+    book { nil }
+    heading { "MyString" }
+    content { "MyText" }
+    is_free { false }
+    position { 1 }
+  end
+end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :book do
+    title { "MyString" }
+    description { "MyText" }
+  end
+end

--- a/spec/models/book_section_spec.rb
+++ b/spec/models/book_section_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe BookSection, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Book, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### 概要
Books/BookSections のモデル・マイグレーションを追加した。

**作業内容**

- Books/BookSections のモデル・マイグレーションを作成した（rails g modelコマンド）
- マイグレーションファイルを編集した上で、マイグレーションを実行した
- ActiveStorage を導入した
-  Books/BookSections モデルを編集した
- 手動で動作確認を行った