### PR TITLE
feat(admin): Admin::BookSectionsにQuillエディタを導入し、フォーム・サニタイズ・i18n・RSpecを実装

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,4 +1,30 @@
 @import "tailwindcss";
 
+/* 本文レンダリング用。Tailwindのリセットを上書き */
+.content-body h1 { font-size: 1.75rem; font-weight: 700; margin: 1.25rem 0 .75rem; }
+.content-body h2 { font-size: 1.5rem;  font-weight: 700; margin: 1.25rem 0 .75rem; }
+.content-body h3 { font-size: 1.25rem; font-weight: 700; margin: 1rem 0 .5rem; }
+
+.content-body p  { margin: 1rem 0; line-height: 1.8; }
+.content-body a  { color: #0369a1; text-decoration: underline; }
+
+.content-body ul { list-style: disc;    padding-left: 1.5rem; margin: 1rem 0; }
+.content-body ol { list-style: decimal; padding-left: 1.5rem; margin: 1rem 0; }
+
+.content-body blockquote {
+  border-left: 4px solid #e2e8f0; padding-left: 1rem; color: #475569; margin: 1rem 0;
+}
+
+.content-body pre {
+  background: #0f172a; color: #e2e8f0; padding: 1rem; border-radius: .5rem;
+  overflow-x: auto; line-height: 1.6;
+}
+.content-body code, .content-body pre, .content-body pre code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+/* Quill のコードブロック用クラス */
+.content-body pre.ql-syntax { background: #0f172a; }
+
 /* Tailwind v4 は CSS から直接 @plugin が書ける。URL 指定でOK（npm不要） */
 /* @plugin "https://cdn.jsdelivr.net/npm/@tailwindcss/typography@latest"; */

--- a/app/controllers/admin/book_sections_controller.rb
+++ b/app/controllers/admin/book_sections_controller.rb
@@ -1,13 +1,56 @@
 class Admin::BookSectionsController < Admin::BaseController
+  include ActionView::Helpers::SanitizeHelper
+  layout "admin"
+
   def index
-    head :ok
+    @sections = BookSection.includes(:book).order(updated_at: :desc).page(params[:page])
   end
 
   def new
-    head :ok
+    @section = BookSection.new
+  end
+
+  def create
+    @section = BookSection.new(section_params)
+    @section.content = sanitize_content(@section.content)
+    if @section.save
+      redirect_to admin_book_sections_path, notice: "作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
-    head :ok
+    @section = BookSection.find(params[:id])
+  end
+
+  def update
+    @section = BookSection.find(params[:id])
+    attrs = section_params
+    attrs[:content] = sanitize_content(attrs[:content])
+    if @section.update(attrs)
+      redirect_to admin_book_sections_path, notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    BookSection.find(params[:id]).destroy
+    redirect_to admin_book_sections_path, notice: "削除しました"
+  end
+
+  private
+
+  def section_params
+    params.require(:book_section).permit(:book_id, :heading, :content, :position, :is_free, images: [])
+  end
+
+  # 表示側で html_safe にしない運用でも一旦安全
+  def sanitize_content(html)
+    sanitize(html,
+      tags: %w[p h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li pre code blockquote br span div img],
+      attributes: %w[href class target rel src alt]
+    )
   end
 end

--- a/app/javascript/controllers/quill_controller.js
+++ b/app/javascript/controllers/quill_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    const editorEl = document.getElementById("quill-editor")
+    const hiddenEl = document.getElementById("content_field")
+    if (!editorEl || !hiddenEl || !window.Quill) return
+
+    this.quill = new Quill(editorEl, {
+      theme: "snow",
+      placeholder: "本文を入力…",
+      modules: {
+        toolbar: [
+          [{ header: [1, 2, 3, false] }],
+          ["bold", "italic", "underline", "code"],
+          [{ list: "ordered" }, { list: "bullet" }],
+          ["link", "blockquote", "code-block", "clean"]
+        ]
+      }
+    })
+
+    // 編集時に既存HTMLを流し込む
+    if (hiddenEl.value) editorEl.querySelector(".ql-editor").innerHTML = hiddenEl.value
+
+    // 内容を hidden に同期
+    this.quill.on("text-change", () => {
+      hiddenEl.value = editorEl.querySelector(".ql-editor").innerHTML
+    })
+  }
+}

--- a/app/views/admin/book_sections/_form.html.erb
+++ b/app/views/admin/book_sections/_form.html.erb
@@ -1,0 +1,73 @@
+<%= form_with model: @section,
+              url: (@section.new_record? ? admin_book_sections_path : admin_book_section_path(@section)),
+              method: (@section.new_record? ? :post : :patch),
+              data: { controller: "quill" } do |f| %>
+
+  <div class="grid gap-8 text-[17px]">  <!-- 全体を少し大きめに -->
+
+    <!-- 教本（セレクト） -->
+    <div class="space-y-2">
+      <%= f.label :book_id, class: "block font-semibold text-slate-800" %>
+      <%= f.collection_select :book_id, Book.order(:title), :id, :title, {},
+            class: "w-full md:w-[28rem] rounded-md border border-slate-300 bg-white px-3 py-2
+                    shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500" %>
+    </div>
+
+    <!-- Position / Is free / Heading（見出しは横並びで値を入力） -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div class="space-y-2">
+        <%= f.label :position, class: "block font-semibold text-slate-800" %>
+        <%= f.number_field :position, min: 0,
+              class: "w-40 rounded-md border border-slate-300 bg-white px-3 py-2
+                      shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500" %>
+      </div>
+
+      <div class="flex items-center gap-3 pt-7 md:pt-0">
+        <%= f.check_box :is_free, class: "h-5 w-5 align-middle rounded border-slate-300
+                                        text-sky-600 focus:ring-sky-500" %>
+        <%= f.label :is_free, class: "font-semibold text-slate-800" %>
+      </div>
+
+      <!-- Heading：入力を横並びに -->
+      <div class="flex items-center gap-3">
+        <%= f.label :heading, class: "shrink-0 font-semibold text-slate-800" %>
+        <%= f.text_field :heading,
+              class: "flex-1 rounded-md border border-slate-300 bg-white px-3 py-2
+                      shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500" %>
+      </div>
+    </div>
+
+    <!-- 本文（Quill 編集用） -->
+    <div class="space-y-2">
+      <%= f.label :content, class: "block font-semibold text-slate-800" %>
+      <div id="quill-editor" class="bg-white rounded min-h-[18rem] mb-6 ql-container ql-snow"></div>
+      <%= f.hidden_field :content, id: "content_field", autocomplete: "off" %>
+    </div>
+
+    <!-- 画像 -->
+    <div class="mt-20 space-y-2">
+      <%= f.label :images, class: "block font-semibold text-slate-800" %>
+      <%= f.file_field :images, multiple: true, direct_upload: true,
+            class: "block w-full max-w-md text-sm text-slate-600
+                    file:mr-4 file:px-4 file:py-2
+                    file:rounded-lg file:border file:border-slate-300
+                    file:bg-white file:font-medium
+                    file:text-slate-700 hover:file:bg-slate-50" %>
+
+      <% if @section.images.attached? %>
+        <ul class="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <% @section.images.each do |img| %>
+            <li><%= image_tag img.variant(resize_to_limit: [400, 400]).processed, class: "rounded" %></li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+
+    <!-- 送信ボタン -->
+    <div class="pt-2">
+      <%= f.submit(@section.new_record? ? "作成する" : "更新する",
+            class: "inline-flex items-center rounded-lg bg-slate-900 px-5 py-2.5
+                    text-white hover:bg-slate-800 disabled:opacity-50") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/book_sections/edit.html.erb
+++ b/app/views/admin/book_sections/edit.html.erb
@@ -1,4 +1,2 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::BookSections#edit</h1>
-  <p>Find me in app/views/admin/book_sections/edit.html.erb</p>
-</div>
+<h1 class="text-2xl font-semibold mb-4">Section編集</h1>
+<%= render "form" %>

--- a/app/views/admin/book_sections/index.html.erb
+++ b/app/views/admin/book_sections/index.html.erb
@@ -1,4 +1,32 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::BookSections#index</h1>
-  <p>Find me in app/views/admin/book_sections/index.html.erb</p>
+<h1 class="text-2xl font-semibold mb-4">Sections</h1>
+<div class="mb-4">
+  <%= link_to "新規作成", new_admin_book_section_path, class: "px-3 py-2 rounded bg-slate-900 text-white" %>
 </div>
+
+<table class="w-full text-left border bg-white">
+  <thead>
+    <tr class="border-b bg-slate-50">
+      <th class="px-3 py-2">ID</th>
+      <th class="px-3 py-2">Book</th>
+      <th class="px-3 py-2">Heading</th>
+      <th class="px-3 py-2">Position</th>
+      <th class="px-3 py-2">更新日</th>
+      <th class="px-3 py-2"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @sections.each do |s| %>
+      <tr class="border-b">
+        <td class="px-3 py-2"><%= s.id %></td>
+        <td class="px-3 py-2"><%= s.book.title %></td>
+        <td class="px-3 py-2"><%= s.heading %></td>
+        <td class="px-3 py-2"><%= s.position %></td>
+        <td class="px-3 py-2 text-slate-500"><%= l s.updated_at, format: :short %></td>
+        <td class="px-3 py-2 text-right">
+          <%= link_to "編集", edit_admin_book_section_path(s), class: "mr-2 text-sky-700 hover:underline" %>
+          <%= link_to "削除", admin_book_section_path(s), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "text-red-700 hover:underline" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/book_sections/new.html.erb
+++ b/app/views/admin/book_sections/new.html.erb
@@ -1,4 +1,2 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::BookSections#new</h1>
-  <p>Find me in app/views/admin/book_sections/new.html.erb</p>
-</div>
+<h1 class="text-2xl font-semibold mb-4">Section作成</h1>
+<%= render "form" %>

--- a/app/views/book_sections/show.html.erb
+++ b/app/views/book_sections/show.html.erb
@@ -6,7 +6,8 @@
   <%= @section.position %>. <%= @section.heading %>
 </h1>
 
-<article class="prose prose-slate max-w-none">
+<!-- <article class="prose prose-slate max-w-none"> -->
+<article class="content-body max-w-none">
   <%= render_section_content(@section) %>
 </article>
 

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -7,20 +7,20 @@
       <!-- だれでも表示 -->
       <%= link_to "Code Editor", editor_path,
           class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
-      <!-- だれでも表示：Rails Books -->
       <%= link_to "Rails Books", books_path,
           class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
 
       <% if logged_in? %>
         <%= link_to "PreCode", pre_codes_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
         <%= link_to "Code Library", code_libraries_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
 
-        <%= link_to "新規作成", new_pre_code_path,
-            class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
+        <!-- ★ 管理者だけに表示 -->
+        <% if current_user&.admin? %>
+          <%= link_to "管理画面", admin_root_path,
+              class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
+        <% end %>
 
         <%= link_to "ログアウト", session_path,
             data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },
@@ -28,10 +28,8 @@
       <% else %>
         <%= link_to "Code Library", code_libraries_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
         <%= link_to "ログイン", new_session_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
         <%= link_to "新規登録", new_user_path,
             class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
       <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,3 +10,17 @@ ja:
       default: "%Y/%m/%d %H:%M"
       short:   "%m/%d %H:%M"
       long:    "%Y年%-m月%-d日 %H:%M"
+  activerecord:
+    attributes:
+      book_section:
+        book_id: "対象の教本"
+        position: "表示順"
+        is_free: "無料公開"
+        heading: "見出し"
+        content: "本文"
+        images: "画像（複数可）"
+  helpers:
+    submit:
+      book_section:
+        create: "作成する"
+        update: "更新する"

--- a/spec/requests/admin/book_sections_spec.rb
+++ b/spec/requests/admin/book_sections_spec.rb
@@ -2,11 +2,25 @@
 require "rails_helper"
 
 RSpec.describe "Admin::BookSections", type: :request do
-  let(:admin) { create(:user, admin: true, password: "password") }
+  let(:admin) { create(:user, admin: true) }
+  let(:book)  { create(:book) }
 
-  it "GET /admin/book_sections は 200" do
-    sign_in_as(admin)
+  before { sign_in_as(admin) }
+
+  it "GET /admin/book_sections works" do
     get admin_book_sections_path
     expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Sections")
+  end
+
+  it "POST creates with sanitized content" do
+    html = %(<p>hello</p><script>alert(1)</script>)
+    post admin_book_sections_path, params: {
+      book_section: { book_id: book.id, heading: "H", position: 1, content: html }
+    }
+    follow_redirect!
+    expect(response.body).to include("作成しました")
+    expect(BookSection.last.content).to include("<p>hello</p>")
+    expect(BookSection.last.content).not_to include("<script")
   end
 end


### PR DESCRIPTION
### 概要
Admin::BookSectionsにQuillエディタを導入し、管理画面でリッチテキスト編集を可能にした

**作業内容**

- Admin::BookSectionsコントローラーを編集し、保存時にHTMLをsanitizeする処理を追加
- app/views/admin/book_sections/_form.html.erb を作成し、Quillエディタとhiddenフィールドの同期を実装
- Stimulusコントローラー（app/javascript/controllers/quill_controller.js）を追加し、Quillの初期化・同期処理を定義
- ビューファイル（index, new, edit, _form）を整備し、管理UIを改善（Position・Heading・セレクトUIなど）
- i18n設定を追加（config/locales/ja.yml）、フォーム項目を日本語ラベル化
- 一般ユーザー側の表示でTailwind Typographyが効かない問題に対して、応急処置として content-body クラスを追加し、CSSでhタグ・リスト・blockquote・codeを調整
- RSpec（spec/requests/admin/book_sections_spec.rb）を追加し、サニタイズ処理のテストを実装
- 動作確認（手動 / RSpec）を実施