### PR TITLE
Gretelでパンくずを導入し、定義・表示パーシャル・主要/管理画面への適用（編集表記統一・任意のJSON-LD対応）を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem "httparty"
 gem "image_processing", "~> 1.12"  # ActiveStorageで画像のリサイズやサムネイル生成を行うGem
 gem "mini_magick"                  # 画像処理ライブラリImageMagickのRubyラッパー
 
+# パンくず機能
+gem "gretel"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,9 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gretel (5.0.1)
+      actionview (>= 6.1)
+      railties (>= 6.1)
     hashie (5.0.0)
     httparty (0.23.1)
       csv
@@ -495,6 +498,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  gretel
   httparty
   image_processing (~> 1.12)
   importmap-rails

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -1,0 +1,18 @@
+# app/helpers/breadcrumbs_helper.rb
+module BreadcrumbsHelper
+  def breadcrumbs_json_ld
+    list = breadcrumbs.map.with_index(1) do |c, i|
+      {
+        "@type": "ListItem",
+        position: i,
+        name: c.text.to_s,
+        item: (c.path ? url_for(c.path) : nil)
+      }.compact
+    end
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: list
+    }.to_json
+  end
+end

--- a/app/views/admin/book_sections/edit.html.erb
+++ b/app/views/admin/book_sections/edit.html.erb
@@ -1,2 +1,8 @@
+<% breadcrumb :root %>
+<% breadcrumb :admin_root %>
+<% breadcrumb :admin_book_sections %>
+<% breadcrumb :admin_book_section_edit, @section %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-semibold mb-4">Section編集</h1>
 <%= render "form" %>

--- a/app/views/admin/book_sections/index.html.erb
+++ b/app/views/admin/book_sections/index.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :admin_book_sections %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-semibold mb-4">Sections</h1>
 <div class="mb-4">
   <%= link_to "新規作成", new_admin_book_section_path, class: "px-3 py-2 rounded bg-slate-900 text-white" %>

--- a/app/views/admin/book_sections/new.html.erb
+++ b/app/views/admin/book_sections/new.html.erb
@@ -1,2 +1,5 @@
+<% breadcrumb :admin_book_sections %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-semibold mb-4">Section作成</h1>
 <%= render "form" %>

--- a/app/views/admin/books/edit.html.erb
+++ b/app/views/admin/books/edit.html.erb
@@ -1,3 +1,9 @@
+<% breadcrumb :root %>
+<% breadcrumb :admin_root %>
+<% breadcrumb :admin_books %>
+<% breadcrumb :admin_book_edit, @book %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "Books / 編集" %>
 <h1 class="text-xl font-semibold mb-4">Book を編集</h1>
 <%= render "form", book: @book %>

--- a/app/views/admin/books/index.html.erb
+++ b/app/views/admin/books/index.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :admin_books %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "Books" %>
 <div class="flex items-center justify-between mb-4">
   <h1 class="text-2xl font-semibold">Books</h1>

--- a/app/views/admin/books/new.html.erb
+++ b/app/views/admin/books/new.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :admin_books %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "Books / 新規作成" %>
 <h1 class="text-xl font-semibold mb-4">Book を新規作成</h1>
 <%= render "form", book: @book %>

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :admin_root %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "Dashboard" %>
 <h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
 

--- a/app/views/book_sections/show.html.erb
+++ b/app/views/book_sections/show.html.erb
@@ -1,3 +1,8 @@
+<% breadcrumb :books %>
+<% breadcrumb :book, @book %>
+<% breadcrumb :book_section, @book, @section %>
+<%= render "shared/breadcrumbs" %>
+
 <nav class="mb-6 text-sm">
   <%= link_to "← #{@book.title} に戻る", book_path(@book), class: "text-slate-600 hover:underline" %>
 </nav>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/books/index.html.erb -->
+<% breadcrumb :books %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-semibold mb-6">教本一覧</h1>
 
 <ul class="divide-y divide-slate-200 rounded-lg border bg-white">

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,4 +1,8 @@
 <!-- app/views/books/show.html.erb -->
+<% breadcrumb :books %>
+<% breadcrumb :book, @book %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-3xl font-bold mb-3"><%= @book.title %></h1>
 <p class="text-slate-600 mb-6"><%= @book.description %></p>
 

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/code_libraries/index.html.erb -->
+<% breadcrumb :code_libraries %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "コードライブラリ" %>
 
 <div class="mb-4 space-y-3">

--- a/app/views/code_libraries/show.html.erb
+++ b/app/views/code_libraries/show.html.erb
@@ -1,4 +1,8 @@
 <!-- app/views/code_libraries/show.html.erb -->
+<% breadcrumb :code_libraries %>
+<% breadcrumb :code_library, @pre_code %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-semibold mb-2"><%= @pre_code.title %></h1>
 <p class="text-slate-600 mb-6"><%= simple_format @pre_code.description %></p>
 

--- a/app/views/editor/index.html.erb
+++ b/app/views/editor/index.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/editor/index.html.erb -->
+<% breadcrumb :editor %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "コードエディタ" %>
 
 <div class="mx-auto max-w-4xl px-4 py-6 space-y-4" data-controller="editor">

--- a/app/views/pre_codes/edit.html.erb
+++ b/app/views/pre_codes/edit.html.erb
@@ -1,3 +1,8 @@
+<% breadcrumb :root %>
+<% breadcrumb :pre_codes %>
+<% breadcrumb :pre_code_edit, @pre_code %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "PreCode編集" %>
 <h1 class="text-xl font-semibold mb-4"><%= yield :title %></h1>
 <%= render "form", pre_code: @pre_code %>

--- a/app/views/pre_codes/index.html.erb
+++ b/app/views/pre_codes/index.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :pre_codes %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "My PreCodes" %>
 
 <div class="flex justify-between items-center mb-4">

--- a/app/views/pre_codes/new.html.erb
+++ b/app/views/pre_codes/new.html.erb
@@ -1,3 +1,8 @@
+<% breadcrumb :root %>
+<% breadcrumb :pre_codes %>
+<% breadcrumb :pre_code_new %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "PreCode新規作成" %>
 <h1 class="text-xl font-semibold mb-4"><%= yield :title %></h1>
 <%= render "form", pre_code: @pre_code %>

--- a/app/views/pre_codes/show.html.erb
+++ b/app/views/pre_codes/show.html.erb
@@ -1,3 +1,8 @@
+<% @pre_code ||= @code %> <%# ← もし変数名が違う場合の保険（不要なら削除） %>
+<% breadcrumb :pre_codes %>
+<% breadcrumb :pre_code, @pre_code %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, @pre_code.title %>
 
 <h1 class="text-xl font-semibold mb-2"><%= @pre_code.title %></h1>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,23 @@
+<%# app/views/shared/_breadcrumbs.html.erb %>
+<% if breadcrumbs.any? %>
+  <nav class="mb-4 text-sm text-slate-500" aria-label="Breadcrumb">
+    <ol class="flex flex-wrap gap-1 items-center">
+      <% breadcrumbs.each_with_index do |crumb, i| %>
+        <li class="inline-flex items-center">
+          <% if crumb.url.present? %>
+            <%# 現在ページだけリンクにしない場合はこちら %>
+            <%= link_to_unless_current crumb.text, crumb.url, class: "hover:underline" do %>
+              <span class="text-slate-700"><%= crumb.text %></span>
+            <% end %>
+          <% else %>
+            <span class="text-slate-700"><%= crumb.text %></span>
+          <% end %>
+
+          <% unless i == breadcrumbs.size - 1 %>
+            <span class="px-1 select-none">›</span>
+          <% end %>
+        </li>
+      <% end %>
+    </ol>
+  </nav>
+<% end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,116 @@
+# config/breadcrumbs.rb
+
+# ============================================================
+# 共通（サイト共通の最上位）
+# ============================================================
+crumb :root do
+  link "ホーム", root_path
+end
+
+
+# ============================================================
+# 一般（Public）エリア
+# ============================================================
+
+# --- Code Editor ---
+crumb :editor do
+  parent :root
+  link "Code Editor", editor_path
+end
+
+# --- Rails Books ---
+crumb :books do
+  parent :root
+  link "Rails Books", books_path
+end
+
+crumb :book do |book|
+  parent :books
+  link book.title, book_path(book)
+end
+
+# 本の中の Section（公開側）
+crumb :book_section do |book, section|
+  parent :book, book
+  # 例）"2. 環境構築"
+  link "#{section.position}. #{section.heading}", book_section_path(book, section)
+end
+
+# --- PreCode ---
+crumb :pre_codes do
+  parent :root
+  link "PreCode", pre_codes_path
+end
+
+crumb :pre_code do |code|
+  parent :pre_codes
+  link code.title, pre_code_path(code)
+end
+
+crumb :pre_code_new do
+  parent :pre_codes
+  link "新規作成", new_pre_code_path
+end
+
+crumb :pre_code_edit do |code|
+  parent :pre_codes
+  link "#{code.title}：編集", edit_pre_code_path(code)
+end
+
+# --- Code Library ---
+crumb :code_libraries do
+  parent :root
+  link "Code Library", code_libraries_path
+end
+
+crumb :code_library do |lib|
+  parent :code_libraries
+  link lib.title, code_library_path(lib)
+end
+
+
+# ============================================================
+# 管理（Admin）エリア
+# ============================================================
+
+# ダッシュボード（管理の起点）
+crumb :admin_root do
+  parent :root
+  link "ダッシュボード", admin_root_path
+end
+
+# --- Admin: Books ---
+crumb :admin_books do
+  parent :admin_root
+  link "Books", admin_books_path
+end
+
+# 管理側 Book 詳細（show が無いなら edit にしてOK）
+crumb :admin_book do |book|
+  parent :admin_books
+  link book.title, admin_book_path(book) # showが無ければ edit_admin_book_path(book) に変更可
+end
+
+# 管理側 Book 編集（「タイトル：編集」表記）
+crumb :admin_book_edit do |book|
+  parent :admin_books
+  link "#{book.title}：編集", edit_admin_book_path(book)
+end
+
+# --- Admin: Sections ---
+crumb :admin_book_sections do
+  parent :admin_root
+  link "Sections", admin_book_sections_path
+end
+
+# 管理側 Section 詳細（show が無ければ edit にしてOK）
+crumb :admin_book_section do |section|
+  parent :admin_book_sections
+  link section.heading, admin_book_section_path(section) # showが無ければ edit_admin_book_section_path(section)
+end
+
+# 管理側 Section 編集（「見出し：編集」表記）
+crumb :admin_book_section_edit do |section|
+  parent :admin_book_sections
+  link "#{section.heading}：編集", edit_admin_book_section_path(section)
+end


### PR DESCRIPTION
### 概要
主要ページと管理画面にパンくず（Gretel）を実装し、ナビゲーション性（＋任意でSEO）を向上させた。

**作業内容**

- gretel を導入し、config/breadcrumbs.rb を整理して作成
- 表示用パーシャル app/views/shared/_breadcrumbs.html.erb を追加
- 任意のSEO向け BreadcrumbsHelper#breadcrumbs_json_ld を追加
- 各ビューにパンくずキーを配置：Editor、Books、BookSections、PreCode、CodeLibrary、Admin
- クリック不可問題・管理パンくずの起点を「ダッシュボード」に修正し、動作確認・簡易リファクタを実施