### PR TITLE
feat: ハンバーガーメニュー（Stimulusモーダル）を導入し、ヘッダー導線の整理・UI改善・関連RSpecを安定化

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,28 @@
+// app/javascript/controllers/modal_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["container", "panel", "backdrop"]
+
+  connect() {
+    this._onKeydown = (e) => { if (e.key === "Escape") this.close() }
+  }
+
+  open() {
+    this.containerTarget.classList.remove("hidden")
+    document.body.classList.add("overflow-hidden")
+    document.addEventListener("keydown", this._onKeydown)
+
+    const f = this.panelTarget.querySelector("[data-autofocus]") ||
+              this.panelTarget.querySelector("a,button,input,select,textarea,[tabindex]:not([tabindex='-1'])")
+    if (f) f.focus()
+  }
+
+  close() {
+    this.containerTarget.classList.add("hidden")
+    document.body.classList.remove("overflow-hidden")
+    document.removeEventListener("keydown", this._onKeydown)
+  }
+
+  backdrop(e) { if (e.target === this.backdropTarget) this.close() }
+}

--- a/app/views/shared/_modal_panel.html.erb
+++ b/app/views/shared/_modal_panel.html.erb
@@ -1,0 +1,66 @@
+<!-- app/views/shared/_modal_panel.html.erb -->
+<div
+  data-modal-target="container"
+  class="hidden fixed inset-0 z-50 grid place-items-start md:place-items-center pt-24 md:pt-0"
+  role="dialog" aria-modal="true" aria-labelledby="user-menu-title">
+
+  <!-- 背景 -->
+  <div
+    data-modal-target="backdrop"
+    class="absolute inset-0 bg-black/40"
+    data-action="click->modal#backdrop"></div>
+
+  <!-- パネル -->
+  <div
+    data-modal-target="panel"
+    class="relative mx-auto w-11/12 max-w-lg rounded-2xl bg-white p-8 shadow-lg text-center">
+
+    <div class="mb-4 flex items-center justify-center">
+      <h2 id="user-menu-title" class="text-xl font-semibold">メニュー</h2>
+      <button
+        class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
+        data-action="click->modal#close"
+        aria-label="閉じる">×</button>
+    </div>
+
+    <% if logged_in? %>
+      <ul class="space-y-3">
+        <li><%= link_to "アプリの使い方", help_path,         class: "block hover:underline text-center" %></li>
+        <li><%= link_to "お問い合わせ",   contact_path,      class: "block hover:underline text-center" %></li>
+        <li><%= link_to "利用規約",       terms_path,        class: "block hover:underline text-center" %></li>
+        <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
+
+        <% if current_user&.admin? %>
+          <li class="pt-2 border-t">
+            <%= link_to "管理画面へログイン", admin_root_path, class: "block hover:underline text-center" %>
+          </li>
+        <% end %>
+
+        <li class="pt-2 border-t">
+          <%= link_to "ログアウト", session_path,
+                      data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },
+                      class: "block hover:underline text-center" %>
+        </li>
+      </ul>
+    <% else %>
+      <ul class="space-y-3">
+        <li><%= link_to "アプリの使い方",   help_path,        class: "block hover:underline text-center" %></li>
+        <li><%= link_to "お問い合わせ",     contact_path,     class: "block hover:underline text-center" %></li>
+        <li><%= link_to "利用規約",         terms_path,       class: "block hover:underline text-center" %></li>
+        <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
+        <li class="pt-2 border-t">
+          <%= link_to "ログイン",     new_session_path, class: "block hover:underline text-center" %>
+        </li>
+        <li>
+          <%= link_to "新規登録",     new_user_path,    class: "block hover:underline text-center" %>
+        </li>
+      </ul>
+    <% end %>
+
+    <div class="mt-6 flex justify-center">
+      <button
+        class="inline-flex items-center rounded-lg bg-rose-600 px-5 py-2 text-white hover:bg-rose-700"
+        data-action="click->modal#close">閉じる</button>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,38 +1,41 @@
 <!-- app/views/shared/_nav.html.erb -->
 <header class="border-b bg-white">
-  <div class="mx-auto max-w-3xl px-4 py-3 flex items-center justify-between">
+  <!-- ここをコントローラの“親”にする（トリガーとモーダルを同じスコープに） -->
+  <div class="mx-auto max-w-3xl px-4 py-3 flex items-center justify-between"
+       data-controller="modal">
+
     <%= link_to "RailsLearningTest", root_path, class: "font-semibold" %>
 
-    <nav class="flex items-center gap-3 text-sm">
-      <!-- だれでも表示 -->
+    <!-- この位置でモーダルを描画（同じ controller スコープ内） -->
+    <%= render "shared/modal_panel" %>
+
+    <!-- グローバルナビ（従来のリンク） -->
+    <nav class="flex items-center gap-3 text-sm px-4 py-2">
+      <%# だれでも表示 %>
       <%= link_to "Code Editor", editor_path,
           class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
       <%= link_to "Rails Books", books_path,
           class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
+      <%= link_to "PreCode", pre_codes_path,
+          class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
+      <%= link_to "Code Library", code_libraries_path,
+          class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
 
+      <%# ログイン時は 追加アクション無し（ログアウト/管理はモーダルへ集約） %>
       <% if logged_in? %>
-        <%= link_to "PreCode", pre_codes_path,
-            class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-        <%= link_to "Code Library", code_libraries_path,
-            class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
-        <!-- ★ 管理者だけに表示 -->
-        <% if current_user&.admin? %>
-          <%= link_to "管理画面", admin_root_path,
-              class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
-        <% end %>
-
-        <%= link_to "ログアウト", session_path,
-            data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },
-            class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
       <% else %>
-        <%= link_to "Code Library", code_libraries_path,
-            class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
+        <%# 未ログイン時は ヘッダでは「ログイン」のみ表示（新規登録はモーダルへ） %>
         <%= link_to "ログイン", new_session_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-        <%= link_to "新規登録", new_user_path,
-            class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
       <% end %>
     </nav>
+
+    <!-- ハンバーガーボタン -->
+    <button
+      class="p-2 rounded-lg hover:bg-slate-100"
+      data-action="click->modal#open"
+      aria-label="メニューを開く">
+      ≡
+    </button>
   </div>
 </header>


### PR DESCRIPTION
### 概要
Stimulusモーダルでハンバーガーメニューを実装し、ログイン状態に応じてメニューを出し分けた。

**作業内容**

- Stimulusコントローラー modal_controller.js を追加（open/close・ESC・Backdrop対応）
- モーダル用パーシャルを作成し、ログイン/未ログイン/管理者で表示内容を切替
- ヘッダーに三本線トリガーを追加し、ログアウトや管理画面リンクをモーダル側へ移動
- UIを調整（中央揃え、モーダル位置、アクセシビリティ属性）
- RSpecを修正し、目次リストのみを抽出するように変更してテストを安定化