### PR TITLE
認証統合とエディタ出力の修正（重複ユーザー統合・OAuth多段対応・stdout/stderr限定表示）

### DIFF
--- a/app/controllers/omni_auth_controller.rb
+++ b/app/controllers/omni_auth_controller.rb
@@ -1,26 +1,68 @@
+# app/controllers/omni_auth_controller.rb
 class OmniAuthController < ApplicationController
-  # OmniAuthは外部リダイレクト→callbackのみCSRF除外
+  # 外部→callback だけ CSRF 除外（既存仕様を維持）
   protect_from_forgery except: :callback
 
-  # /auth/:provider に直アクセスされた時の穴埋め（Rackが処理するので通常来ない）
+  # /auth/:provider に直アクセスされたときの穴埋め
   def passthru
     head :not_found
   end
 
+  # /auth/:provider/callback
   def callback
-    auth = request.env["omniauth.auth"]
-    user = User.find_or_create_from_omniauth(auth)  # ← Userモデルに用意済みメソッド
+    auth = request.env["omniauth.auth"] or raise "omniauth.auth is nil"
+
+    provider  = auth.provider.to_s            # "google_oauth2" / "github"
+    uid       = auth.uid.to_s
+    info      = auth.info || OpenStruct.new
+    email     = info.email.to_s.downcase.presence
+    display   = provider_label(provider)
+    name      = info.name.presence || email&.split("@")&.first || "#{provider}_user"
+
+    # 1) 既存の認証レコードがある → そのユーザーでログイン
+    if (authentication = Authentication.find_by(provider: provider, uid: uid))
+      user = authentication.user
+      reset_session
+      session[:user_id] = user.id
+      redirect_to root_path, notice: "#{display}でログインしました" and return
+    end
+
+    # 2) 認証レコードは無いが同じメールのユーザーがいる → 既存ユーザーに紐付け
+    if email && (user = User.where("lower(email) = ?", email).first)
+      user.authentications.find_or_create_by!(provider: provider, uid: uid)
+      reset_session
+      session[:user_id] = user.id
+      redirect_to root_path, notice: "#{display}をあなたのアカウントに連携しました" and return
+    end
+
+    # 3) どちらも無ければ新規作成（パスワードはダミー）
+    user = User.create!(
+      name:     name,
+      email:    email,  # 一部プロバイダは nil の可能性あり
+      password: SecureRandom.urlsafe_base64(24)
+    )
+    user.authentications.create!(provider: provider, uid: uid)
+
     reset_session
     session[:user_id] = user.id
+    redirect_to root_path, notice: "#{display}で新規登録しました"
 
-    provider_name = auth.provider.to_s.titleize
-    redirect_to root_path, notice: "#{provider_name}でログインしました"
   rescue => e
-    Rails.logger.error("[OmniAuth] #{e.class}: #{e.message}\n#{e.backtrace&.first}")
+    Rails.logger.error("[OmniAuth #{e.class}] #{e.message}\n#{e.backtrace&.first}")
     redirect_to new_session_path, alert: "外部ログインに失敗しました"
   end
 
   def failure
     redirect_to new_session_path, alert: "外部ログインがキャンセル/失敗しました"
+  end
+
+  private
+
+  def provider_label(provider)
+    case provider
+    when "google_oauth2" then "Google"
+    when "github"        then "GitHub"
+    else provider.to_s.titleize
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,4 @@
+# app/controllers/users_controller.rb
 class UsersController < ApplicationController
   before_action :require_guest!, only: %i[new create]
 
@@ -7,17 +8,37 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params) # provider なし → 通常登録
+
     if @user.save
       session[:user_id] = @user.id
       redirect_to root_path, notice: "登録しました"
     else
-      render :new, status: :unprocessable_entity
+      # モデル側に uniqueness が無い場合でも、実在チェックで拾う
+      if email_taken_for_normal_signup?(@user)
+        redirect_to new_session_path, alert: "そのメールアドレスは既に登録済みです。ログインしてください。"
+      else
+        flash.now[:alert] = "入力内容を確認してください"
+        render :new, status: :unprocessable_entity
+      end
     end
+
+  rescue ActiveRecord::RecordNotUnique
+    # DBレベルの競合も同じメッセージに統一
+    redirect_to new_session_path, alert: "そのメールアドレスは既に登録済みです。ログインしてください。"
   end
 
   private
+
   def user_params
     params.require(:user)
           .permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def email_taken_for_normal_signup?(user)
+    # モデル側 uniqueness が付いていればまずここで true になる
+    return true if user.errors.added?(:email, :taken)
+
+    email = user.email.to_s.downcase
+    User.where("lower(email) = ?", email).exists?
   end
 end

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -63,17 +63,19 @@ export default class extends Controller {
     const btn = event?.currentTarget || this.element.querySelector('[data-action*="editor#run"]')
     btn?.setAttribute("disabled", "disabled")
     this.outputTarget.textContent = "実行中…"
+
     try {
       const code = this.view.state.doc.toString()
-      const res  = await axios.post("/editor", { code })
-      const { status, stdout, stderr, time, memory } = res.data
-      this.outputTarget.textContent =
-        `Status: ${status}\n` +
-        (stdout ? `\n=== stdout ===\n${stdout}` : "") +
-        (stderr ? `\n=== stderr ===\n${stderr}` : "") +
-        (time || memory ? `\n(time: ${time ?? "-"}s, mem: ${memory ?? "-"}KB)` : "")
+      const res = await axios.post("/editor", { code })
+
+      // stdout / stderr のみ返す
+      if (res.data.stderr && res.data.stderr.length > 0) {
+        this.outputTarget.textContent = res.data.stderr
+      } else {
+        this.outputTarget.textContent = res.data.stdout
+      }
     } catch (e) {
-      this.outputTarget.textContent = `Error: ${e?.response?.data?.error || e}`
+      this.outputTarget.textContent = `Error: ${e.response?.data?.stderr || e}`
     } finally {
       btn?.removeAttribute("disabled")
     }

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,16 @@
+# app/models/authentication.rb
+class Authentication < ApplicationRecord
+  belongs_to :user
+
+  PROVIDERS = %w[google_oauth2 github].freeze
+
+  validates :provider, :uid, presence: true
+  validates :uid, uniqueness:   { scope: :provider }
+  validates :provider, inclusion: { in: PROVIDERS }
+  validates :provider, uniqueness: { scope: :user_id }
+
+  # 便利スコープ
+  scope :for_provider,    ->(provider) { where(provider: provider) }
+  scope :google_oauth2,   -> { where(provider: "google_oauth2") }
+  scope :github,          -> { where(provider: "github") }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   has_many :pre_codes, dependent: :destroy
   has_many :likes,      dependent: :destroy
   has_many :used_codes, dependent: :destroy
+  has_many :authentications, dependent: :destroy
 
   # bcrypt
   has_secure_password validations: false
@@ -15,10 +16,12 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }
 
   # 通常ログイン（provider が空のとき）
-  with_options if: -> { provider.blank? } do
-    validates :email, presence: true, length: { maximum: 255 },
-                      format: { with: URI::MailTo::EMAIL_REGEXP }
-  end
+  validates :email,
+    presence: true,
+    length:  { maximum: 255 },
+    format:  { with: URI::MailTo::EMAIL_REGEXP },
+    uniqueness: { case_sensitive: false },
+    if: -> { provider.blank? }
 
   validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
 

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,7 +1,7 @@
 <!-- app/views/shared/_nav.html.erb -->
 <header class="border-b bg-white">
   <!-- モーダルの controller スコープ（トリガーとモーダルを同じ親に） -->
-  <div class="mx-auto max-w-3xl px-4 py-3 flex items-center justify-between"
+  <div class="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-3 flex items-center justify-between"
        data-controller="modal">
 
     <!-- タイトル（常時表示） -->

--- a/db/migrate/20250826215725_create_authentications.rb
+++ b/db/migrate/20250826215725_create_authentications.rb
@@ -1,0 +1,16 @@
+class CreateAuthentications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :authentications do |t|
+      t.references :user, null: false, foreign_key: { on_delete: :cascade } # ユーザー削除で紐づきも削除
+      t.string :provider, null: false
+      t.string :uid,      null: false
+      t.timestamps
+    end
+
+    # グローバル一意：同じ (provider, uid) の組み合わせは世界に1つ
+    add_index :authentications, [ :provider, :uid ], unique: true
+
+    # 同一ユーザーで同じ provider を2本持てないように（誤登録防止）
+    add_index :authentications, [ :user_id, :provider ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_25_143312) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_215725) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_25_143312) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "authentications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid", unique: true
+    t.index ["user_id", "provider"], name: "index_authentications_on_user_id_and_provider", unique: true
+    t.index ["user_id"], name: "index_authentications_on_user_id"
   end
 
   create_table "book_sections", force: :cascade do |t|
@@ -126,6 +137,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_25_143312) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "authentications", "users", on_delete: :cascade
   add_foreign_key "book_sections", "books"
   add_foreign_key "likes", "pre_codes"
   add_foreign_key "likes", "users"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,83 @@
+# lib/tasks/users.rake
+namespace :users do
+  desc "同一メールの重複ユーザーを1つに統合（DRY RUN。適用したいときは EXECUTE=1 を付ける）"
+  task merge_duplicates: :environment do
+    dry = ENV["EXECUTE"] != "1"
+    log = ->(msg) { puts msg }
+
+    # lower(email) でグルーピングし、2件以上あるメールのみ対象
+    emails = User.group("lower(email)").having("count(*) > 1")
+                 .pluck(Arel.sql("lower(email)"))
+
+    emails.each do |email_lc|
+      User.transaction do
+        users = User.lock.where("lower(email) = ?", email_lc).order(:id) # 古い順に
+        keep  = users.first
+        dups  = users.offset(1)
+
+        log.call "[#{email_lc}] keep=#{keep.id}, duplicates=#{dups.size}"
+
+        dups.find_each do |dupe|
+          # --- 1) pre_codes（重複心配なし）そのまま移行 ---
+          if dry
+            log.call "  would move pre_codes(#{dupe.pre_codes.count}) user_id: #{dupe.id} -> #{keep.id}"
+          else
+            dupe.pre_codes.update_all(user_id: keep.id)
+          end
+
+          # --- 2) likes（user_id, pre_code_id の一意制約がある）重複を捨てながら移行 ★ ---
+          dupe.likes.find_each do |like|
+            if Like.exists?(user_id: keep.id, pre_code_id: like.pre_code_id)
+              if dry
+                log.call "  would drop duplicate like pre_code_id=#{like.pre_code_id} (user #{keep.id} already has it)"
+              else
+                like.destroy!  # 片方だけ残す（keep 側を優先）
+              end
+            else
+              if dry
+                log.call "  would move like #{like.id} -> keep"
+              else
+                like.update!(user_id: keep.id)
+              end
+            end
+          end
+
+          # --- 3) used_codes も同様の重複があればケア ★（unique がある場合） ---
+          # もし used_codes に [:user_id, :pre_code_id] の unique があるなら下を有効化
+          dupe.used_codes.find_each do |uc|
+            if UsedCode.exists?(user_id: keep.id, pre_code_id: uc.pre_code_id)
+              if dry
+                log.call "  would drop duplicate used_code pre_code_id=#{uc.pre_code_id} (already at keep)"
+              else
+                uc.destroy!
+              end
+            else
+              if dry
+                log.call "  would move used_code #{uc.id} -> keep"
+              else
+                uc.update!(user_id: keep.id)
+              end
+            end
+          end
+
+          # --- 4) authentications（provider,uid 一意）衝突回避は現状のままでOK ---
+          dupe.authentications.find_each do |a|
+            if keep.authentications.exists?(provider: a.provider, uid: a.uid)
+              dry ? log.call("  skip auth #{a.provider}/#{a.uid} (already on keep)") : a.destroy!
+            else
+              dry ? log.call("  would move auth #{a.provider}/#{a.uid} -> keep") : a.update!(user_id: keep.id)
+            end
+          end
+
+          # --- 5) admin の昇格 & dupe 削除（あなたの元コード通りでOK） ---
+          if dupe.admin? && !keep.admin?
+            dry ? log.call("  would promote keep(#{keep.id}) to admin") : keep.update!(admin: true)
+          end
+          dry ? log.call("  would destroy user #{dupe.id}") : dupe.destroy!
+        end
+      end
+    end
+
+    log.call dry ? "DRY RUN 完了（EXECUTE=1 で適用）" : "統合作業 完了"
+  end
+end

--- a/spec/factories/authentications.rb
+++ b/spec/factories/authentications.rb
@@ -1,0 +1,8 @@
+# spec/factories/authentications.rb
+FactoryBot.define do
+  factory :authentication do
+    association :user
+    provider { "google_oauth2" }
+    sequence(:uid) { |n| "uid-#{n}" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,36 +1,35 @@
 # spec/factories/users.rb
 FactoryBot.define do
-  # === 基本ユーザー（fixtures: normal に対応） ===
+  # === 基本ユーザー（通常登録） ===
   factory :user do
-    name  { 'Normal' }                         # fixturesの値に合わせるなら固定でOK
-    sequence(:email) { |n| "normal#{n}@example.com" }  # 重複回避（fixturesのunique相当）
-    password              { 'password' }       # has_secure_password 用
-    password_confirmation { 'password' }
+    name  { "Normal" }
+    sequence(:email) { |n| "normal#{n}@example.com" }
+    password              { "password" }
+    password_confirmation { "password" }
     provider { nil }
     uid      { nil }
     admin    { false }
+  end
 
-    # === Google ログインユーザー（fixtures: google_user に対応） ===
-    factory :google_user do
-      name     { 'Google Taro' }
-      email    { 'taro@example.com' }
-      provider { 'google_oauth2' }
-      uid      { '12345' }
-      # 外部ログインは password 不要。バリデーションを外している前提（has_secure_password validations: false）
-      password              { nil }
-      password_confirmation { nil }
-      admin { false }
-    end
+  # === Google ログインユーザー（OAuth） ===
+  factory :google_user, class: "User" do
+    name  { "Google Taro" }
+    email { "taro@example.com" }
+    provider { "google_oauth2" }
+    uid      { "g-#{SecureRandom.hex(4)}" }
+    password              { nil }
+    password_confirmation { nil }
+    admin { false }
+  end
 
-    # === GitHub ログインユーザー（fixtures: github_user に対応） ===
-    factory :github_user do
-      name     { 'Octo' }
-      email    { 'octo@example.com' }
-      provider { 'github' }
-      uid      { '99999' }
-      password              { nil }
-      password_confirmation { nil }
-      admin { true }
-    end
+  # === GitHub ログインユーザー（OAuth, 管理者想定） ===
+  factory :github_user, class: "User" do
+    name  { "Octo" }
+    email { "octo@example.com" }
+    provider { "github" }
+    uid      { "gh-#{SecureRandom.hex(4)}" }
+    password              { nil }
+    password_confirmation { nil }
+    admin { true }
   end
 end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,33 @@
+# spec/models/authentication_spec.rb
+require "rails_helper"
+
+RSpec.describe Authentication, type: :model do
+  it "有効なfactoryを持つ" do
+    expect(build(:authentication)).to be_valid
+  end
+
+  it "user, provider, uid は必須" do
+    expect(build(:authentication, user: nil)).to be_invalid
+    expect(build(:authentication, provider: nil)).to be_invalid
+    expect(build(:authentication, uid: nil)).to be_invalid
+  end
+
+  it "同一(provider, uid) は世界で一意" do
+    a1 = create(:authentication, provider: "google_oauth2", uid: "X")
+    a2 = build(:authentication, provider: a1.provider, uid: a1.uid)
+    expect(a2).to be_invalid
+  end
+
+  it "同一ユーザーが同じproviderを二重に持てない" do
+    user = create(:user)
+    create(:authentication, user:, provider: "github", uid: "G-1")
+    dup  = build(:authentication, user:, provider: "github", uid: "G-2")
+    expect(dup).to be_invalid
+  end
+
+  it "for_provider スコープで絞れる" do
+    g = create(:authentication, provider: "google_oauth2")
+    create(:authentication, provider: "github")
+    expect(Authentication.for_provider("google_oauth2")).to match_array([ g ])
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,18 +1,36 @@
-require 'rails_helper'
+# spec/models/user_spec.rb
+require "rails_helper"
 
 RSpec.describe User, type: :model do
-  it '通常ユーザーのfactoryが有効' do
+  it "通常ユーザーのfactoryが有効" do
     expect(build(:user)).to be_valid
   end
 
-  it 'Googleユーザーのfactoryが有効（password不要）' do
+  it "Googleユーザーのfactoryが有効（password不要）" do
     u = build(:google_user)
     expect(u).to be_valid
   end
 
-  it 'GitHubユーザーのfactoryが有効（admin: true）' do
+  it "GitHubユーザーのfactoryが有効（admin: true）" do
     u = build(:github_user)
     expect(u.admin).to be true
     expect(u).to be_valid
+  end
+
+  describe "email の一意性（通常登録のみ）" do
+    it "email の一意性（通常登録のみ） case-insensitive に重複を弾く（provider: nil 同士）" do
+      create(:user, email: "ALICE@example.com")
+      u = build(:user, email: "alice@EXAMPLE.com")
+
+      u.validate
+      expect(u).to be_invalid
+      expect(u.errors.of_kind?(:email, :taken)).to be true
+    end
+
+    it "OAuthユーザーが同じメールでも、OAuth側は uniqueness 対象外" do
+      create(:user, email: "same@example.com")
+      oauth = build(:google_user, email: "same@example.com")
+      expect(oauth).to be_valid
+    end
   end
 end

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -1,44 +1,118 @@
 # spec/requests/omniauth_spec.rb
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'OmniAuth', type: :request do
-  describe 'GET /auth/:provider' do
-    it 'テストモードでは callback へ302でリダイレクトする' do
-      get auth_path(provider: 'github')
+RSpec.describe "OmniAuth", type: :request do
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+
+  describe "GET /auth/:provider" do
+    it "テストモードでは callback へ302でリダイレクトする" do
+      mock_omniauth(provider: "github", uid: "gh-1", name: "GH User", email: "gh@example.com")
+      get auth_path(provider: "github")
       expect(response).to have_http_status(:found)
-      expect(response).to redirect_to(omni_auth_callback_path(provider: 'github'))
+      expect(response).to redirect_to(omni_auth_callback_path(provider: "github"))
     end
   end
 
-  describe 'GET /auth/:provider/callback' do
-    it '初回はユーザー作成 & ログインする' do
-      mock_omniauth(provider: 'github', uid: 'gh-1', name: 'GH User', email: 'gh@example.com')
-
-      expect {
-        get omni_auth_callback_path(provider: 'github')
-      }.to change(User, :count).by(1)
-
-      expect(response).to redirect_to(root_path)
-      expect(session[:user_id]).to be_present
+  describe "GET /auth/:provider/callback" do
+    context "既存の認証レコードがある" do
+      let!(:auth) { create(:authentication, provider: "google_oauth2", uid: "U-1") }
+      it "ユーザー/認証を増やさず root へ" do
+        mock_omniauth(provider: "google_oauth2", uid: "U-1", email: auth.user.email)
+        expect {
+          get omni_auth_callback_path(provider: "google_oauth2")
+        }.to change(User, :count).by(0).and change(Authentication, :count).by(0)
+        expect(response).to redirect_to(root_path)
+      end
     end
 
-    it '2回目は作成されずログインのみ' do
-      # 1回目で作成
-      mock_omniauth(provider: 'github', uid: 'gh-1', name: 'GH User', email: 'gh@example.com')
-      get omni_auth_callback_path(provider: 'github')
+    context "2) 認証レコード無し + 同じメールの既存ユーザーがいる場合（紐付け）" do
+      let(:provider) { "google_oauth2" }
+      let!(:user)    { create(:user, email: "foo@example.com") }
 
-      # 2回目は作成されない
-      mock_omniauth(provider: 'github', uid: 'gh-1', name: 'GH User', email: 'gh@example.com')
-      expect {
-        get omni_auth_callback_path(provider: 'github')
-      }.not_to change(User, :count)
+      it "ユーザーは増えず、authが1件作成され、rootへリダイレクト" do
+        mock_omniauth(provider:, uid: "NEW-UID", name: "G User", email: "foo@example.com")
 
-      expect(response).to redirect_to(root_path)
+        expect {
+          get omni_auth_callback_path(provider:)
+        }.to change(User, :count).by(0).and change(Authentication, :count).by(1)
+
+        a = Authentication.last
+        expect(a.user_id).to eq(user.id)
+        expect(a.provider).to eq(provider)
+        expect(a.uid).to eq("NEW-UID")
+
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash[:notice]).to satisfy { |m| m&.include?("連携しました") || m&.include?("ログインしました") }
+      end
+    end
+
+    context "3) 認証レコードも該当ユーザーもない場合（新規作成）" do
+      let(:provider) { "google_oauth2" }
+
+      it "ユーザー1件 + auth1件が作成され、rootへリダイレクト" do
+        mock_omniauth(provider:, uid: "BRAND-NEW", name: "G New", email: "new@example.com")
+
+        expect {
+          get omni_auth_callback_path(provider:)
+        }.to change(User, :count).by(1).and change(Authentication, :count).by(1)
+
+        user = User.order(:id).last
+        auth = Authentication.last
+        expect(auth.user_id).to eq(user.id)
+        expect(auth.provider).to eq(provider)
+        expect(auth.uid).to eq("BRAND-NEW")
+        expect(user.email).to eq("new@example.com")
+
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash[:notice]).to satisfy { |m| m&.include?("新規登録しました") || m&.include?("ログインしました") }
+      end
+    end
+
+    context "4) GitHub でも同様に動く（メール一致で既存ユーザーに紐付く）" do
+      let(:provider) { "github" }
+
+      it do
+        user = create(:user, email: "octo@example.com")
+        mock_omniauth(provider:, uid: "GH-1", name: "Octo", email: "octo@example.com")
+
+        expect {
+          get omni_auth_callback_path(provider:)
+        }.to change(User, :count).by(0).and change(Authentication, :count).by(1)
+
+        expect(Authentication.last.provider).to eq("github")
+        expect(Authentication.last.user_id).to eq(user.id)
+      end
+    end
+
+    context "5) 既存コードの回帰: 初回作成→2回目は作成せずログインのみ" do
+      it do
+        # 1回目：新規作成
+        mock_omniauth(provider: "github", uid: "gh-1", name: "GH User", email: "gh@example.com")
+        get omni_auth_callback_path(provider: "github")
+        expect(response).to redirect_to(root_path)
+
+        # 2回目：同じ認証情報 → Userは増えない
+        mock_omniauth(provider: "github", uid: "gh-1", name: "GH User", email: "gh@example.com")
+        expect {
+          get omni_auth_callback_path(provider: "github")
+        }.not_to change(User, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 
-  describe 'GET /auth/failure' do
-    it 'ログイン画面へリダイレクトする' do
+  describe "GET /auth/failure" do
+    it "ログイン画面へリダイレクトする" do
       get omni_auth_failure_path
       expect(response).to redirect_to(new_session_path)
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,5 +1,5 @@
 # spec/requests/users_spec.rb
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Users", type: :request do
   describe "GET /users/new" do
@@ -11,12 +11,61 @@ RSpec.describe "Users", type: :request do
 
   describe "POST /users" do
     it "ユーザーを作成してログインする" do
-      params = { user: { name: "Alice", email: "a@example.com", password: "secret123", password_confirmation: "secret123" } }
+      params = { user: { name: "Alice", email: "a@example.com",
+                         password: "secret123", password_confirmation: "secret123" } }
+
       expect {
         post users_path, params: params
       }.to change(User, :count).by(1)
+
       expect(session[:user_id]).to be_present
       expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(response.body).to include("登録しました")
+    end
+
+    context "既に同じメール（通常登録）が存在する場合" do
+      let!(:existing) { create(:user, email: "dup@example.com") }
+
+      it "作成されず、ログイン画面にリダイレクトしてフラッシュを表示する" do
+        params = { user: { name: "Bob", email: "dup@example.com",
+                           password: "secret123", password_confirmation: "secret123" } }
+
+        expect {
+          post users_path, params: params
+        }.not_to change(User, :count)
+
+        expect(session[:user_id]).to be_nil
+        expect(response).to redirect_to(new_session_path)
+        follow_redirect!
+        expect(response.body).to include("既に登録済みです")
+      end
+
+      it "大文字小文字が違っても同一として扱われる" do
+        params = { user: { name: "Bob", email: "DuP@Example.com",
+                           password: "secret123", password_confirmation: "secret123" } }
+
+        expect {
+          post users_path, params: params
+        }.not_to change(User, :count)
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+
+    context "同じメールのOAuthユーザーが既にいる場合" do
+      let!(:oauth) { create(:google_user, email: "google@example.com") }
+
+      it "（現在の仕様）通常登録は失敗し、ログイン画面に誘導される" do
+        params = { user: { name: "Bob", email: "google@example.com",
+                           password: "secret123", password_confirmation: "secret123" } }
+
+        expect {
+          post users_path, params: params
+        }.not_to change(User, :count)
+
+        expect(response).to redirect_to(new_session_path)
+      end
     end
   end
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,12 +1,24 @@
 # spec/support/omniauth.rb
-require 'omniauth'
+require "omniauth"
 
 OmniAuth.config.test_mode = true
 
 def mock_omniauth(provider:, uid: "u-123", name: "Mock User", email: "mock@example.com")
-  OmniAuth.config.mock_auth[provider.to_sym] = OmniAuth::AuthHash.new(
+  hash = OmniAuth::AuthHash.new(
     provider: provider,
-    uid: uid,
-    info: { name: name, email: email }
+    uid:      uid,
+    info:     { name:, email: }
   )
+
+  # 1) /auth/:provider ルート → ミドルウェアが mock_auth を参照
+  OmniAuth.config.mock_auth[provider.to_sym] = hash
+
+  # 2) /auth/:provider/callback を直接叩くテスト → controller が env を参照
+  Rails.application.env_config["omniauth.auth"] = hash
+end
+
+RSpec.configure do |config|
+  config.after(:each) do
+    Rails.application.env_config.delete("omniauth.auth")
+  end
 end


### PR DESCRIPTION
### 概要
認証の多段対応と重複ユーザー統合タスクを実装し、コードエディタの出力を stdout/stderr のみに整理した。

**作業内容**

- UsersController / User モデルを修正し、同一メールの通常登録はログイン画面へ誘導するよう改善
- authentications テーブルを導入し、複数プロバイダ（Google/GitHub）の統合ログインを実装
- 重複ユーザーを統合する rake タスクを追加し、DRY RUN/EXECUTE 両モードで検証
- EditorController を修正し、Judge0 のレスポンスから余計なメタ情報を除去、stdout/stderr のみに限定
- フロント側の editor_controller.js を修正し、stderr 優先表示/エラー表示の処理を簡潔化