### PR TITLE
MVP指摘対応：ログイン導線の追加／エラーメッセージ日本語化／CodeLibraryのlikes・used_codesをTurbo対応

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,11 +1,14 @@
+# app/controllers/likes_controller.rb
 class LikesController < ApplicationController
   before_action :require_login!
+  before_action :set_pre_code, only: [ :create, :destroy ]
 
   def create
-    @pre_code = PreCode.find(params[:pre_code_id])
-    return head :forbidden if @pre_code.user_id == current_user.id  # 自分の投稿は弾く
-    Like.create!(user: current_user, pre_code: @pre_code)
+    return head :forbidden if @pre_code.user_id == current_user.id
 
+    current_user.likes.create!(pre_code: @pre_code)
+
+    @pre_code.reload
     respond_to do |f|
       f.turbo_stream
       f.html { redirect_back fallback_location: code_libraries_path }
@@ -15,12 +18,26 @@ class LikesController < ApplicationController
   end
 
   def destroy
-    like = current_user.likes.find(params[:id])     # ← 自分のもの以外は404
+    like = current_user.likes.find(params[:id])
     @pre_code = like.pre_code
-    like.destroy
+    like.destroy!
+
+    @pre_code.reload
     respond_to do |f|
       f.turbo_stream
       f.html { redirect_back fallback_location: code_libraries_path }
     end
+  end
+
+  private
+
+  def set_pre_code
+    @pre_code =
+      if params[:pre_code_id].present?
+        PreCode.find(params[:pre_code_id])
+      else
+        # destroy 時は :id から like をたどるケースもあるため保険
+        current_user.likes.find(params[:id]).pre_code
+      end
   end
 end

--- a/app/controllers/used_codes_controller.rb
+++ b/app/controllers/used_codes_controller.rb
@@ -1,16 +1,29 @@
+# app/controllers/used_codes_controller.rb
 class UsedCodesController < ApplicationController
   before_action :require_login!
+  before_action :set_pre_code, only: :create
 
   def create
-    @pre_code = PreCode.find(params[:pre_code_id])
-    return head :forbidden if @pre_code.user_id == current_user.id  # 自分の投稿は弾く
+    # 自分の投稿は弾く
+    return head :forbidden if @pre_code.user_id == current_user.id
+
+    # 1ユーザー1レコード
     UsedCode.find_or_create_by!(user: current_user, pre_code: @pre_code) do |uc|
       uc.used_at = Time.current
     end
+
+    # 表示用に最新値へリロード
+    @pre_code.reload
 
     respond_to do |f|
       f.turbo_stream
       f.html { redirect_back fallback_location: code_libraries_path }
     end
+  end
+
+  private
+
+  def set_pre_code
+    @pre_code = PreCode.find(params[:pre_code_id])
   end
 end

--- a/app/views/code_libraries/_metrics.html.erb
+++ b/app/views/code_libraries/_metrics.html.erb
@@ -1,0 +1,11 @@
+<%# 右側アイコン＋カウンタ（置換対象） %>
+<div id="<%= dom_id(pre_code, :metrics) %>" class="text-sm text-slate-500 shrink-0">
+  <span class="inline-flex items-center gap-1 mr-4 align-middle">
+    <%= heroicon "heart",  variant: :solid,   options: { class: "w-4 h-4" } %>
+    <%= pre_code.like_count %>
+  </span>
+  <span class="inline-flex items-center gap-1 align-middle">
+    <%= heroicon "briefcase", variant: :outline, options: { class: "w-4 h-4" } %>
+    <%= pre_code.use_count %>
+  </span>
+</div>

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -45,16 +45,7 @@
           <% end %>
 
           <!-- 右側：メトリクスやボタン（リンクの外） -->
-          <div class="text-sm text-slate-500 shrink-0">
-            <span class="inline-flex items-center gap-1 mr-4 align-middle">
-              <%= heroicon "heart", variant: :solid, options: { class: "w-4 h-4" } %>
-              <%= pc.like_count %>
-            </span>
-            <span class="inline-flex items-center gap-1 align-middle">
-              <%= heroicon "briefcase", variant: :outline, options: { class: "w-4 h-4" } %>
-              <%= pc.use_count %>
-            </span>
-          </div>
+          <%= render "metrics", pre_code: pc %>
         </div>
 
         <div class="mt-3">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,27 +18,42 @@
     <%# CSS / JS 読み込み %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= turbo_include_tags %>
   </head>
 
-  <body class="bg-slate-50 text-slate-800">
+  <body class="min-h-screen flex flex-col bg-slate-50 text-slate-800">
     <!-- ヘッダー -->
     <%= render "shared/nav" %>
 
-    <!-- メイン -->
-    <main class="<%= content_for?(:page_container_class) \
+    <!-- メイン（高さだけ担当） -->
+    <main class="flex-1">
+      <!-- 幅・左右余白はここで集中管理 -->
+      <div class="<%= content_for?(:page_container_class) \
                     ? yield(:page_container_class) \
                     : 'mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-6' %>">
-      <%= render "shared/flash" %>
-      <%= yield %>
+        <%= render "shared/flash" %>
+        <%= yield %>
+      </div>
     </main>
-  </body>
 
-  <footer class="mt-12 py-8 text-sm text-slate-500">
-    <div class="mx-auto max-w-md px-4 flex flex-wrap gap-4">
-      <%= link_to "利用規約", terms_path, class: "hover:underline" %>
-      <%= link_to "プライバシー", privacy_path, class: "hover:underline" %>
-      <%= link_to "ヘルプ", help_path, class: "hover:underline" %>
-      <%= link_to "お問い合わせ", contact_path, class: "hover:underline" %>
-    </div>
-  </footer>
+    <!-- フッター -->
+    <footer class="mt-12 border-t bg-white/50">
+      <div class="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 items-center gap-4">
+          <!-- 左：リンク群 -->
+          <ul class="flex flex-wrap gap-x-6 gap-y-2 text-sm text-slate-500 w-full sm:w-auto justify-center sm:justify-start">
+            <li><%= link_to "利用規約", terms_path, class: "hover:underline" %></li>
+            <li><%= link_to "プライバシーポリシー", privacy_path, class: "hover:underline" %></li>
+            <li><%= link_to "アプリの使い方", help_path, class: "hover:underline" %></li>
+            <li><%= link_to "お問い合わせ", contact_path, class: "hover:underline" %></li>
+          </ul>
+
+          <!-- 右：コピーライト -->
+          <p class="text-xs text-slate-400 text-center sm:text-right w-full sm:w-auto">
+            © <%= Time.current.year %> Rails Learning
+          </p>
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -4,3 +4,7 @@
         pre_code: @pre_code,
         current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>
+  <%= render "code_libraries/metrics", pre_code: @pre_code %>
+<% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -4,3 +4,7 @@
         pre_code: @pre_code,
         current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>
+  <%= render "code_libraries/metrics", pre_code: @pre_code %>
+<% end %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,22 +1,28 @@
 <% content_for :title, "パスワード再設定" %>
-<h1 class="text-xl font-semibold mb-4">新しいパスワードを設定</h1>
 
-<%= form_with model: @user,
-              url: password_reset_path(params[:id]),
-              method: :patch,
-              class: "space-y-4" do |f| %>
-  <%= render "shared/errors", model: @user %>
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
 
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-    <div>
-      <%= f.label :password, "新しいパスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-    </div>
-    <div>
-      <%= f.label :password_confirmation, "確認用パスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-    </div>
+    <h1 class="text-xl font-semibold mb-4 text-center">パスワード再設定</h1>
+
+    <p class="text-sm text-gray-600 text-center">
+      再設定したいパスワードを入力してください。
+    </p>
+
+    <%= form_with model: @user, url: password_reset_path(params[:id]), method: :patch, class: "space-y-4 pb-2" do |f| %>
+      <%= render "shared/errors", model: @user %>
+
+      <div>
+        <%= f.label :password, "パスワード", class: "block text-sm mb-1" %>
+        <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500", placeholder: "8文字以上 20文字未満" %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm mb-1" %>
+        <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500", placeholder: "8文字以上 20文字未満" %>
+      </div>
+
+      <%= f.submit "送信", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
   </div>
-
-  <%= f.submit "更新する", class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-<% end %>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,15 +1,29 @@
 <% content_for :title, "パスワード再設定" %>
-<h1 class="text-xl font-semibold mb-4">パスワード再設定メールを送る</h1>
 
-<%= form_with url: password_resets_path, scope: nil, class: "space-y-4" do |f| %>
-  <div>
-    <label class="block text-sm mb-1" for="email">登録メールアドレス</label>
-    <input
-      type="email" name="email" id="email"
-      class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500"
-      placeholder="you@example.com" />
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
+
+    <h1 class="text-xl font-semibold mb-4 text-center">パスワードをお忘れの方</h1>
+
+    <p class="text-sm text-gray-600 text-center">
+      登録したメールアドレスを入力してください。<br>
+      パスワードリセット用のリンクを送信します。
+    </p>
+
+    <%= form_with url: password_resets_path, scope: nil, class: "space-y-4" do |f| %>
+      <div>
+        <label class="block text-sm mb-1" for="email">メールアドレス</label>
+        <input type="email" name="email" id="email"
+          class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500"
+          placeholder="メールアドレスを入力してください" />
+      </div>
+
+      <%= f.submit "送信", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
+
+    <div class="text-center">
+      <%= link_to "ログインページに戻る", new_session_path, class: "text-sm text-slate-600 hover:underline" %>
+    </div>
+
   </div>
-
-  <%= f.submit "送信する",
-        class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-<% end %>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,25 +1,39 @@
 <% content_for :title, "ログイン" %>
-<h1 class="text-xl font-semibold mb-4">ログイン</h1>
 
-<%= form_with url: session_path, scope: nil, class: "space-y-4" do |f| %>
-  <div>
-    <label class="block text-sm mb-1" for="email">メールアドレス</label>
-    <input type="email" name="email" id="email"
-           class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
-  </div>
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
+    <h1 class="text-2xl font-bold text-center">ログイン</h1>
 
-  <div>
-    <label class="block text-sm mb-1" for="password">パスワード</label>
-    <input type="password" name="password" id="password"
-           class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
-  </div>
+    <%= form_with url: session_path, scope: nil, class: "space-y-4" do |f| %>
+      <div>
+        <label class="block text-sm mb-1" for="email">メールアドレス</label>
+        <input type="email" name="email" id="email" class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
+      </div>
 
-  <div class="flex items-center gap-3">
-    <%= f.submit "ログイン", class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-    <%= link_to "パスワードをお忘れですか？", new_password_reset_path, class: "text-sm text-slate-500 hover:underline" %>
-  </div>
+      <div>
+        <label class="block text-sm mb-1" for="password">パスワード</label>
+        <input type="password" name="password" id="password" class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
+      </div>
 
-  <div class="mt-6">
-    <%= render "shared/oauth_buttons" %>
+      <%= f.submit "ログイン", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
+
+    <div class="flex justify-between text-sm text-slate-600">
+      <%= link_to "パスワード再設定", new_password_reset_path, class: "hover:underline" %>
+      <%= link_to "新規登録", new_user_path, class: "hover:underline" %>
+    </div>
+
+    <div class="relative my-4">
+      <div class="absolute inset-0 flex items-center">
+        <div class="w-full border-t border-gray-300"></div>
+      </div>
+      <div class="relative flex justify-center text-sm">
+        <span class="bg-white px-2 text-gray-500">または</span>
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <%= render "shared/oauth_buttons" %>
+    </div>
   </div>
-<% end %>
+</div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -7,7 +7,7 @@
     <!-- タイトル（常時表示） -->
     <%= link_to root_path, class: "font-semibold text-center md:text-left flex items-center gap-2" do %>
       <%= heroicon "rocket-launch", variant: :outline, options: { class: "w-6 h-6" } %>
-      <span>RailsLearningTest</span>
+      <span>Rails Learning Test</span>
     <% end %>
 
     <!-- === グローバルナビ＋ハンバーガー（右寄せ） === -->
@@ -31,7 +31,7 @@
 
       <!-- ハンバーガー：モバイルで表示 -->
       <button
-        class="p-2 rounded-lg hover:bg-slate-100 md:hidden lg:block"
+        class="p-2 rounded-lg hover:bg-slate-100 lg:block"
         data-action="click->modal#open"
         aria-label="メニューを開く">
         <%= heroicon "bars-3", options: { class: "w-6 h-6 text-slate-500" } %>

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -1,19 +1,150 @@
 <!-- app/views/static_pages/help.html.erb -->
+<%# パンくず %>
 <% breadcrumb :root %>
 <% breadcrumb :help %>
 <%= render "shared/breadcrumbs" %>
 
 <% content_for :title, "ヘルプ" %>
-<h1 class="text-2xl font-bold mb-4">ヘルプ</h1>
-<section class="prose max-w-none">
-  <h2>使い方</h2>
-  <p>このサービスの基本操作や各機能の説明をまとめます。</p>
 
-  <h3>主な機能</h3>
-  <ul>
-    <li>Code Editor（実行・テーマ切替・初期データ）</li>
-    <li>Rails Books（目次・前後ページ）</li>
-    <li>PreCode / CodeLibrary（ランキング・いいね）</li>
-    <li>…など</li>
-  </ul>
-</section>
+<div class="mx-auto max-w-3xl space-y-10">
+  <!-- ページ見出し -->
+  <h1 class="text-2xl font-bold mb-2">🚀 RailsLearning の使い方</h1>
+  <hr class="border-slate-200">
+
+  <!-- Code Editor -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📝 Code Editor（コードエディタ）</h2>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p class="mt-1">
+        アプリ上で Ruby や Rails のコードを入力・実行できる機能です。学習した内容をすぐに試し、その場で結果を確認できます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>「初期データ」プルダウンからサンプルコードを選択できます。</li>
+        <li>エディタ欄に自由にコードを入力してください。</li>
+        <li>▶ <span class="font-semibold">実行</span> ボタンを押すと、下部に実行結果が表示されます。</li>
+        <li>テーマ切替ボタンで、ダーク／ライトモードを切り替えられます。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>学習中のコード断片を気軽に試す場として利用してください。</li>
+        <li>保存はされないため、成果を残したい場合は PreCode 機能の利用がおすすめです。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- PreCode -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📦 PreCode（プリコード）</h2>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p class="mt-1">
+        「自分専用のコード断片（スニペット）」を保存できる機能です。頻繁に使うコードや学習メモを整理して残せます。簡単な Ruby の問題を作ることもできます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>右上の「新規作成」から PreCode を登録します。</li>
+        <li><span class="font-semibold">タイトル</span>、<span class="font-semibold">説明</span>（用途や補足）、<span class="font-semibold">コード本体</span>を入力します。</li>
+        <li>保存後は一覧に追加され、クリックで詳細を確認できます。</li>
+        <li>編集・削除も可能です。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>学習メモやよく使う処理の記録に最適です。</li>
+        <li>自動リサイズフォーム＋残り文字数カウンタで、長文でも扱いやすくなっています。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- Code Library -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📚 Code Library（コードライブラリ）</h2>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p class="mt-1">
+        ユーザーが作成した PreCode を「共有ライブラリ」として一覧・検索できる機能です。他人のコードを参考にしたり、人気コードを学習に活かせます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>検索フォームからタイトルや説明でコードを検索できます。</li>
+        <li>並び替えで「人気順」「利用数順」「新着順」を切り替えられます。</li>
+        <li>各コードページでは「いいね ❤️」や「使った 🧰」を押してリアクションできます。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>学習仲間がどんなコードを使っているか参考にできます。</li>
+        <li>自分のコードが他の人に使われるとモチベーションUPにつながります。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- Rails Books -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📖 Rails Books（Railsテキスト）</h2>
+
+    <div class="space-y-2">
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p>
+        Rails の基礎から応用を体系的に学べる教材ページです。章ごとに整理されており、目次から順番に読み進められます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>書籍一覧ページから教材を選びます。</li>
+        <li>各書籍には <span class="font-semibold">章の一覧（目次）</span> があり、クリックで内容を閲覧できます。</li>
+        <li>章ページでは本文を読み進めながら、前後の章に移動できます。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>一部の章には「FREE」ラベルがあり、無料で閲覧可能です。</li>
+        <li>基礎から体系的に進められるため、カリキュラム学習の補助にも使えます。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- まとめ -->
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold">✅ まとめ</h2>
+    <ul class="list-disc ml-6 space-y-1">
+      <li><span class="font-semibold">Code Editor</span>：その場でコードを実行</li>
+      <li><span class="font-semibold">PreCode</span>：自分のコードメモを保存</li>
+      <li><span class="font-semibold">Code Library</span>：共有ライブラリで学び合い</li>
+      <li><span class="font-semibold">Rails Books</span>：体系的な教材で学習</li>
+    </ul>
+  </section>
+</div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -4,10 +4,112 @@
 <%= render "shared/breadcrumbs" %>
 
 <% content_for :title, "プライバシーポリシー" %>
-<h1 class="text-2xl font-bold mb-4">プライバシーポリシー</h1>
-<section class="prose max-w-none">
-  <h2>個人情報の利用目的</h2>
-  <p>…</p>
-  <h2>アクセス解析・Cookie</h2>
-  <p>…</p>
-</section>
+
+<div class="mx-auto max-w-3xl">
+  <h1 class="text-2xl font-bold mb-6">プライバシーポリシー</h1>
+
+  <div class="space-y-6 text-slate-700">
+    <div>
+      <p>
+        本プライバシーポリシー（以下、「本ポリシー」といいます。）は、当サービスが取得するユーザーの情報とその取扱いについて定めるものです。<br>
+        ユーザーの皆さまは、本ポリシーに同意のうえ本サービスをご利用ください。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">1. 取得する情報</h2>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>アカウント情報（氏名・ニックネーム、メールアドレス 等）</li>
+        <li>利用状況に関する情報（アクセス日時、閲覧ページ、検索条件、端末情報、IPアドレス 等）</li>
+        <li>お問い合わせ時に入力いただく情報</li>
+        <li>Cookie 等の識別子・広告識別子</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">2. 利用目的</h2>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>本サービスの提供・維持・保護および改善のため</li>
+        <li>利用状況の把握、機能改善や新機能開発のための分析のため</li>
+        <li>不正利用の防止、セキュリティ対策のため</li>
+        <li>問い合わせ対応・重要なお知らせの連絡のため</li>
+        <li>法令・規約等に基づく対応のため</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">3. 取得方法</h2>
+      <p>
+        ユーザーの入力による取得のほか、アクセス解析ツールや Cookie 等を用いて自動的に取得する場合があります。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">4. Cookie・アクセス解析</h2>
+      <p>
+        本サービスでは、利便性向上・利用状況の把握のために Cookie 等の技術を使用することがあります。<br>
+        ブラウザ設定により Cookie の受け入れを拒否できますが、サービスの一部機能が利用できない場合があります。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">5. 第三者提供</h2>
+      <p>
+        当社は、次の場合を除き、本人の同意なく個人情報を第三者に提供しません。<br>
+      </p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>法令に基づく場合</li>
+        <li>人の生命・身体または財産の保護のために必要がある場合</li>
+        <li>業務委託先に取り扱いを委託する場合（委託先は適切に監督します）</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">6. 外部送信・委託</h2>
+      <p>
+        本サービスの運営にあたり、サーバ運用やアクセス解析等を外部事業者へ委託し、必要な範囲で情報が送信されることがあります。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">7. 安全管理措置</h2>
+      <p>
+        取得した情報は、アクセス制御・暗号化・ログ監査等、適切な安全管理措置を講じて取り扱います。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">8. 開示・訂正・利用停止等の請求</h2>
+      <p>
+        ユーザーは、当社所定の手続により、自己の個人情報の開示・訂正・利用停止等を請求できます。<br>
+        具体的な手続は「お問い合わせ」よりご連絡ください。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">9. 未成年者の利用</h2>
+      <p>
+        未成年の方が本サービスを利用する場合、親権者等の同意を得た上でご利用ください。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">10. ポリシーの変更</h2>
+      <p>
+        本ポリシーの内容は、法令の改正やサービス内容の変更等により、事前の予告なく変更されることがあります。<br>
+        変更後のポリシーは、本サービス上に掲示した時点から効力を生じます。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">11. お問い合わせ</h2>
+      <p>
+        本ポリシーに関するお問い合わせは、本サービス内の連絡手段よりご連絡ください。
+      </p>
+    </div>
+
+    <div class="text-xs text-slate-500">
+      最終更新日：<%= Date.today.strftime("%Y-%m-%d") %>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -4,10 +4,68 @@
 <%= render "shared/breadcrumbs" %>
 
 <% content_for :title, "利用規約" %>
-<h1 class="text-2xl font-bold mb-4">利用規約</h1>
-<section class="prose max-w-none">
-  <h2>第1条 適用</h2>
-  <p>…（後で本番文面に差し替え）</p>
-  <h2>第2条 禁止事項</h2>
-  <ul><li>…</li></ul>
-</section>
+
+<div class="mx-auto max-w-3xl">
+  <h1 class="text-2xl font-bold mb-6">利用規約</h1>
+
+  <div class="space-y-6 text-slate-700">
+    <p>
+      この利用規約（以下、「本規約」といいます。）は、当サービスの利用条件を定めるものです。<br>
+      ユーザーの皆さまには、本規約に従って本サービスをご利用いただきます。
+    </p>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第1条（適用）</h2>
+      <p>
+        本規約は、ユーザーと当サービス運営者との間の本サービス利用に関わる一切の関係に適用されるものとします。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第2条（禁止事項）</h2>
+      <p>ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>法令または公序良俗に違反する行為</li>
+        <li>犯罪行為に関連する行為</li>
+        <li>本サービスの運営を妨害する行為</li>
+        <li>不正アクセスや不正な操作を試みる行為</li>
+        <li>その他、運営者が不適切と判断する行為</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第3条（サービスの提供の停止等）</h2>
+      <p>
+        運営者は、以下のいずれかに該当すると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止することができます。
+      </p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>システム保守や更新を行う場合</li>
+        <li>地震、火災、停電、天災地変など不可抗力によりサービス提供が困難な場合</li>
+        <li>その他、運営者がサービス提供を困難と判断した場合</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第4条（免責事項）</h2>
+      <p>
+        運営者は、本サービスの内容の変更、中断、終了によってユーザーに生じた損害について、一切の責任を負わないものとします。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第5条（規約の変更）</h2>
+      <p>
+        運営者は、必要と判断した場合には、本規約を変更することができます。<br>
+        変更後の利用規約は、本サービスに掲載した時点で効力を生じるものとします。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第6条（準拠法・裁判管轄）</h2>
+      <p>
+        本規約の解釈には、日本法を準拠法とします。<br>
+        本サービスに関して紛争が生じた場合には、運営者の所在地を管轄する裁判所を専属的合意管轄とします。
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/used_codes/create.turbo_stream.erb
+++ b/app/views/used_codes/create.turbo_stream.erb
@@ -4,3 +4,7 @@
         pre_code: @pre_code,
         current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>
+  <%= render "code_libraries/metrics", pre_code: @pre_code %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,36 +1,50 @@
 <% content_for :title, "新規登録" %>
-<h1 class="text-xl font-semibold mb-4">新規登録</h1>
 
-<%= form_with model: @user, url: users_path, class: "space-y-4" do |f| %>
-  <%= render "shared/errors", model: @user %>
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
 
-  <div>
-    <%= f.label :name, "名前", class: "block text-sm mb-1" %>
-    <%= f.text_field :name, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-  </div>
+    <h1 class="text-2xl font-bold text-center">新規登録</h1>
 
-  <div>
-    <%= f.label :email, "メールアドレス", class: "block text-sm mb-1" %>
-    <%= f.email_field :email, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-  </div>
+    <%= form_with model: @user, url: users_path, class: "space-y-4" do |f| %>
+      <div>
+        <%= f.label :name, "ユーザー名", class: "block text-sm mb-1" %>
+        <%= f.text_field :name, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
 
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-    <div>
-      <%= f.label :password, "パスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      <div>
+        <%= f.label :email, "メールアドレス", class: "block text-sm mb-1" %>
+        <%= f.email_field :email, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
+
+      <div>
+        <%= f.label :password, "パスワード", class: "block text-sm mb-1" %>
+        <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm mb-1" %>
+        <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
+
+      <%= f.submit "新規登録", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
+
+    <div class="flex justify-end text-sm text-slate-600">
+      <%= link_to "ログインページへ", new_session_path, class: "hover:underline" %>
     </div>
-    <div>
-      <%= f.label :password_confirmation, "確認用パスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+
+    <div class="relative my-4">
+      <div class="absolute inset-0 flex items-center">
+        <div class="w-full border-t border-gray-300"></div>
+      </div>
+      <div class="relative flex justify-center text-sm">
+        <span class="bg-white px-2 text-gray-500">または</span>
+      </div>
     </div>
-  </div>
 
-  <div class="flex items-center gap-3">
-    <%= f.submit "登録する", class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-    <%= link_to "ログインページへ", new_session_path, class: "text-sm text-slate-500 hover:underline" %>
-  </div>
+    <div class="space-y-2">
+      <%= render "shared/oauth_buttons" %>
+    </div>
 
-  <div class="mt-6">
-    <%= render "shared/oauth_buttons" %>
   </div>
-<% end %>
+</div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -47,3 +47,4 @@ pin "@codemirror/legacy-modes/mode/ruby",
 pin "@codemirror/theme-one-dark", to: "https://esm.sh/@codemirror/theme-one-dark@6"
 # ハイライト (tags / HighlightStyle の提供元)
 pin "@lezer/highlight", to: "https://esm.sh/@lezer/highlight@1/es2022/highlight.mjs"
+pin "@hotwired/stimulus", to: "stimulus.min.js"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,8 +19,16 @@ ja:
         heading: "見出し"
         content: "本文"
         images: "画像（複数可）"
+      pre_code:
+        title: "タイトル"
+        body: "コードの説明"
+    models:
+      pre_code: "PreCode"
   helpers:
     submit:
       book_section:
         create: "作成する"
         update: "更新する"
+  errors:
+    messages:
+      blank: "を入力してください"

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 
 RSpec.describe "Likes", type: :request do
   let(:user)     { create(:user, password: "secret123", password_confirmation: "secret123") }
-  let(:pre_code) { create(:pre_code) }
+  let(:author)   { create(:user, password: "secret123", password_confirmation: "secret123") }
+  let(:pre_code) { create(:pre_code, user: author) }
 
   describe "認可" do
     it "未ログインは作成にアクセスできずリダイレクト" do
@@ -21,7 +22,7 @@ RSpec.describe "Likes", type: :request do
       }.to change(Like, :count).by(1)
        .and change { pre_code.reload.like_count }.by(1)
 
-      # Turbo Stream or リダイレクトのどちらでも許容
+      # Turbo Stream / リダイレクトのどちらでも許容
       expect(response).to have_http_status(:ok).or have_http_status(:found)
     end
 
@@ -39,10 +40,24 @@ RSpec.describe "Likes", type: :request do
         delete like_path(like)
       }.to change(Like, :count).by(-1)
        .and change { pre_code.reload.like_count }.by(-1)
+
       expect(response).to have_http_status(:ok).or have_http_status(:found)
     end
 
-    it "他人の Like は削除できず 404（RecordNotFound → 404 rescue）" do
+    # === ここを追加 ===
+    it "自分の投稿にはいいねできず :forbidden で件数も増えない" do
+      my_pre_code = create(:pre_code, user: user)
+      expect {
+        post likes_path, params: { pre_code_id: my_pre_code.id }
+      }.not_to change(Like, :count)
+      expect(my_pre_code.reload.like_count).to eq(0)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "削除ガード" do
+    it "他人の Like は削除できず 404" do
+      sign_in(user)
       other_like = create(:like, pre_code: pre_code) # 別ユーザー
       delete like_path(other_like)
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/used_codes_spec.rb
+++ b/spec/requests/used_codes_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 
 RSpec.describe "UsedCodes", type: :request do
   let(:user)     { create(:user, password: "secret123", password_confirmation: "secret123") }
-  let(:pre_code) { create(:pre_code) }
+  let(:author)   { create(:user, password: "secret123", password_confirmation: "secret123") }
+  let(:pre_code) { create(:pre_code, user: author) }
 
   describe "認可" do
     it "未ログインは作成にアクセスできずリダイレクト" do
@@ -20,6 +21,7 @@ RSpec.describe "UsedCodes", type: :request do
         post used_codes_path, params: { pre_code_id: pre_code.id }
       }.to change(UsedCode, :count).by(1)
        .and change { pre_code.reload.use_count }.by(1)
+
       expect(response).to have_http_status(:ok).or have_http_status(:found)
     end
 
@@ -29,6 +31,16 @@ RSpec.describe "UsedCodes", type: :request do
         post used_codes_path, params: { pre_code_id: pre_code.id }
       }.not_to change(UsedCode, :count)
       expect(pre_code.reload.use_count).to eq(1)
+    end
+
+    # === ここを追加 ===
+    it "自分の投稿は利用記録を作れず :forbidden で件数も増えない" do
+      my_pre_code = create(:pre_code, user: user)
+      expect {
+        post used_codes_path, params: { pre_code_id: my_pre_code.id }
+      }.not_to change(UsedCode, :count)
+      expect(my_pre_code.reload.use_count).to eq(0)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end


### PR DESCRIPTION
### 概要
MVPフィードバックの3点（導線・文言・非同期）をまとめて解消。

**作業内容**

- ログイン／新規登録／パスワード再設定画面に相互リンクを追加し導線を補強
- config/locales/ja.yml を拡充し、PreCode等の属性名・エラー文を日本語化
- CodeLibraryの右側メトリクスをパーシャル化（dom_id 付与）し置換ターゲットを定義
- Likes／UsedCodes の Turbo Stream テンプレートを実装し、actions と metrics を同時更新
- controllersを整理（自分の投稿は :forbidden、counter_cache反映のため @pre_code.reload ）