### PR TITLE
管理画面にユーザー管理機能を追加（検索・編集者切替・凍結・削除対応）

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,40 @@
+class Admin::UsersController < Admin::BaseController
+  layout "admin"
+
+  before_action :set_user, only: [ :toggle_editor, :toggle_ban, :destroy ]
+
+  def index
+    @q = params[:q]
+    @filter = params[:filter]
+
+    @users = User.search(@q)
+                 .yield_self { |u| @filter == "editors" ? u.editors : u }
+                 .yield_self { |u| @filter == "banned" ? u.banned : u }
+                 .order(created_at: :desc)
+                 .page(params[:page]).per(50)
+  end
+
+  def toggle_editor
+    return redirect_back fallback_location: admin_users_path, alert: "管理者は変更不可" if @user.admin?
+    @user.toggle_editor!
+    redirect_back fallback_location: admin_users_path, notice: "編集者権限を更新しました"
+  end
+
+  def toggle_ban
+    return redirect_back fallback_location: admin_users_path, alert: "管理者は凍結不可" if @user.admin?
+    @user.toggle_ban!(params[:ban_reason])
+    redirect_back fallback_location: admin_users_path, notice: "ユーザー状態を更新しました"
+  end
+
+  def destroy
+    return redirect_back fallback_location: admin_users_path, alert: "管理者は削除不可" if @user.admin?
+    @user.destroy!
+    redirect_to admin_users_path, notice: "ユーザーを削除しました"
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/views/admin/users/destroy.html.erb
+++ b/app/views/admin/users/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#destroy</h1>
+<p>Find me in app/views/admin/users/destroy.html.erb</p>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,111 @@
+<!-- app/views/admin/users/index.html.erb -->
+<h1 class="text-xl font-semibold text-slate-900 mb-4">ユーザー管理</h1>
+
+<%= form_with url: admin_users_path, method: :get, local: true, class: "mb-6" do %>
+  <div class="flex flex-wrap items-end gap-3">
+    <div class="grow min-w-[220px]">
+      <%= text_field_tag :q, params[:q],
+            placeholder: "名前またはメールを検索",
+            class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900" %>
+    </div>
+
+    <div>
+      <%= select_tag :filter,
+            options_for_select([["すべて", ""], ["編集者のみ", "editors"], ["凍結中のみ", "banned"]], params[:filter]),
+            class: "rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-900" %>
+    </div>
+
+    <div>
+      <%= submit_tag "検索",
+            class: "inline-flex items-center rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800" %>
+    </div>
+  </div>
+<% end %>
+
+<div class="overflow-x-auto rounded-lg ring-1 ring-slate-200 bg-white">
+  <table class="min-w-full divide-y divide-slate-200">
+    <thead class="bg-slate-50">
+      <tr>
+        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">名前</th>
+        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">メール</th>
+        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">権限</th>
+        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">状態</th>
+        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">操作</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-100 text-sm">
+      <% @users.each do |u| %>
+        <tr class="hover:bg-slate-50/60">
+          <td class="px-4 py-2 font-medium text-slate-900"><%= u.name %></td>
+          <td class="px-4 py-2 text-slate-700"><%= u.email %></td>
+
+          <!-- 権限バッジ：管理者/編集者/一般） -->
+          <td class="px-4 py-2">
+            <% if u.admin? %>
+              <span class="inline-flex items-center rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+                管理者
+              </span>
+            <% elsif u.editor? %>
+              <span class="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-200">
+                編集者
+              </span>
+            <% else %>
+              <span class="inline-flex items-center rounded-full bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600 ring-1 ring-inset ring-slate-200">
+                一般
+              </span>
+            <% end %>
+          </td>
+
+          <!-- 凍結/有効バッジ -->
+          <td class="px-4 py-2">
+            <% if u.banned? %>
+              <span class="inline-flex items-center rounded-full bg-rose-50 px-2.5 py-0.5 text-xs font-medium text-rose-700 ring-1 ring-inset ring-rose-200">凍結中</span>
+            <% else %>
+              <span class="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200">有効</span>
+            <% end %>
+          </td>
+
+          <!-- 操作 -->
+          <td class="px-4 py-2">
+            <% unless u.admin? %>
+              <div class="flex flex-wrap gap-2">
+                <%= button_to "編集者切替",
+                      toggle_editor_admin_user_path(u),
+                      method: :patch,
+                      class: "inline-flex items-center rounded-md bg-white px-3 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-300 hover:bg-slate-50" %>
+
+                <%#-- 凍結ボタンの表示ラベルと色を先に決める --%>
+                <% ban_label = u.banned? ? "解除" : "凍結" %>
+                <% ban_color = u.banned? ? "bg-emerald-600 hover:bg-emerald-700 ring-emerald-600"
+                                         : "bg-rose-600 hover:bg-rose-700 ring-rose-600" %>
+
+                <%= button_to ban_label,
+                      toggle_ban_admin_user_path(u),
+                      method: :patch,
+                      params: { ban_reason: "手動操作" },
+                      data: { turbo_confirm: (u.banned? ? "凍結を解除します。よろしいですか？" : "このユーザーを凍結します。よろしいですか？") },
+                      class: "inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium text-white ring-1 #{ban_color}" %>
+
+                <%= button_to "削除",
+                      admin_user_path(u),
+                      method: :delete,
+                      data: { turbo_confirm: "このユーザーと関連データを削除します（復元不可）。よろしいですか？" },
+                      class: "inline-flex items-center rounded-md bg-white px-3 py-1.5 text-xs font-medium text-rose-700 ring-1 ring-rose-300 hover:bg-rose-50" %>
+              </div>
+            <% else %>
+              <span class="text-xs text-slate-400">管理者は操作不可</span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @users.blank? %>
+    <div class="p-6 text-center text-sm text-slate-500">該当するユーザーが見つかりませんでした。</div>
+  <% end %>
+</div>
+
+<div class="mt-6">
+  <%= paginate @users %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -35,6 +35,7 @@
           <%= link_to "Dashboard", admin_root_path %>
           <%= link_to "Books",     admin_books_path %>
           <%= link_to "Sections",  admin_book_sections_path %>
+          <%= link_to "Users",     admin_users_path %>
 
           <% if current_user&.admin? %>
             <%= button_to "Logout",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,12 @@ Rails.application.routes.draw do
     resource  :session,   only: %i[new create destroy]
     resources :books
     resources :book_sections, except: %i[show]
+    resources :users, only: [ :index, :destroy ] do
+      member do
+        patch :toggle_editor
+        patch :toggle_ban
+      end
+    end
   end
 
   # OmniAuth

--- a/db/migrate/20250923181851_add_admin_flags_to_users.rb
+++ b/db/migrate/20250923181851_add_admin_flags_to_users.rb
@@ -1,0 +1,7 @@
+class AddAdminFlagsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :editor, :boolean, default: false, null: false
+    add_column :users, :banned_at, :datetime
+    add_column :users, :ban_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_23_150356) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_23_181851) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -131,6 +131,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_23_150356) do
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "editor", default: false, null: false
+    t.datetime "banned_at"
+    t.string "ban_reason"
     t.index "lower((email)::text)", name: "index_users_on_lower_email_unique", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token_unique", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,22 @@ FactoryBot.define do
     password              { "secret123" }
     password_confirmation { "secret123" }
     admin { false }
+
+    # 編集者権限 ON
+    trait :editor do
+      editor { true }
+    end
+
+    # 凍結状態（理由付き）
+    trait :banned do
+      banned_at { Time.current }
+      ban_reason { "spam" }
+    end
+
+    # 管理者フラグ ON（github_user 以外でも使いたい時用）
+    trait :admin do
+      admin { true }
+    end
   end
 
   # ===== OAuth（Google）=====

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Users", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:target) { create(:user) }
+
+  before { sign_in admin }
+
+  describe "GET /admin/users" do
+    it "一覧が表示される" do
+      target = create(:user, email: "test_user@example.com")
+      get admin_users_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("test_user@example.com")
+    end
+  end
+
+  describe "PATCH /toggle_editor" do
+    it "編集者権限を切替できる" do
+      patch toggle_editor_admin_user_path(target)
+      expect(target.reload.editor).to eq(true)
+    end
+  end
+
+  describe "PATCH /toggle_ban" do
+    it "BANを設定できる" do
+      patch toggle_ban_admin_user_path(target), params: { ban_reason: "test" }
+      expect(target.reload).to be_banned
+    end
+  end
+
+  describe "DELETE /users/:id" do
+    it "ユーザーを削除できる" do
+      delete admin_user_path(target)
+      expect(User.exists?(target.id)).to eq(false)
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -23,5 +23,20 @@ RSpec.describe "Sessions", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(session[:user_id]).to be_blank
     end
+
+    context "BAN中ユーザーの場合" do
+      let!(:banned) do
+        # 既存Factoryに :banned trait を追加済みなのでそれを利用
+        create(:user, :banned, email: "b@example.com", password: "secret123", password_confirmation: "secret123")
+      end
+
+      it "403で拒否し、セッションはセットされない" do
+        post session_path, params: { email: "b@example.com", password: "secret123" }
+        expect(response).to have_http_status(:forbidden)
+        expect(session[:user_id]).to be_blank
+        # メッセージの確認（文言は実装に合わせて）
+        expect(response.body).to include("凍結")
+      end
+    end
   end
 end


### PR DESCRIPTION
### 概要
管理画面にユーザー管理を追加し、権限切替・凍結といった運用フローを一通りカバーした。

**作業内容**

- users に editor:boolean / banned_at:datetime / ban_reason:string を追加する Migration を実装
- User モデルに検索/フィルタ用スコープ、toggle_editor!・toggle_ban!・banned? を実装
- Admin::UsersController#index/toggle_editor/toggle_ban/destroy と一覧画面を追加（検索・編集者/凍結フィルタ・操作ボタン）
- Tailwind で管理画面のユーザー一覧 UI を整備（権限/状態バッジ、管理者は操作不可、ページネーション対応）
- セッション作成時に凍結ユーザーを 403 Forbidden で拒否するガードを追加
- RSpec を追加（admin/users の一覧・切替・凍結・削除、sessions の成功/失敗/凍結時403、Factory 拡充）