### PR TITLE
プロフィール画面を追加し名前・パスワード更新と外部アカウント接続、最終ログイン記録を実装

### DIFF
--- a/app/controllers/omni_auth_controller.rb
+++ b/app/controllers/omni_auth_controller.rb
@@ -1,51 +1,64 @@
 # app/controllers/omni_auth_controller.rb
 class OmniAuthController < ApplicationController
-  # 外部→callback だけ CSRF 除外（既存仕様を維持）
   protect_from_forgery except: :callback
 
-  # /auth/:provider に直アクセスされたときの穴埋め
   def passthru
     head :not_found
   end
 
-  # /auth/:provider/callback
   def callback
-    auth = request.env["omniauth.auth"] or raise "omniauth.auth is nil"
+    auth   = request.env["omniauth.auth"] || (raise "omniauth.auth is nil")
+    prov   = auth.provider.to_s          # "google_oauth2" or "github"
+    uid    = auth.uid.to_s
+    info   = auth.info || OpenStruct.new
+    email  = info.email.to_s.downcase.presence
+    name   = info.name.presence || info.nickname.presence || prov.titleize
 
-    provider  = auth.provider.to_s            # "google_oauth2" / "github"
-    uid       = auth.uid.to_s
-    info      = auth.info || OpenStruct.new
-    email     = info.email.to_s.downcase.presence
-    display   = provider_label(provider)
-    name      = info.name.presence || email&.split("@")&.first || "#{provider}_user"
+    # === ① プロフィールからの「接続」か？（link=1 を見て判定） ===
+    if current_user && params[:link].present?
+      # 他ユーザーに同じ provider+uid が無いか
+      if Authentication.exists?(provider: prov, uid: uid)
+        redirect_to edit_profile_path, alert: "このアカウントは既に他のユーザーに連携されています" and return
+      end
 
-    # 1) 既存の認証レコードがある → そのユーザーでログイン
-    if (authentication = Authentication.find_by(provider: provider, uid: uid))
+      # メール完全一致のみ許可
+      if email.blank? || email.strip.downcase != current_user.email.to_s.strip.downcase
+        redirect_to edit_profile_path, alert: "メールアドレスが違います" and return
+      end
+
+      current_user.authentications.create!(provider: prov, uid: uid)
+      redirect_to profile_path, notice: "外部連携を設定しました" and return
+    end
+
+    # === ② 通常のログインフロー（既存実装） ===
+    authentication = Authentication.find_by(provider: prov, uid: uid)
+    if authentication
       user = authentication.user
       reset_session
       session[:user_id] = user.id
-      redirect_to root_path, notice: "#{display}でログインしました" and return
+      user.update_column(:last_login_at, Time.current)
+      redirect_to root_path, notice: "#{provider_label(prov)}でログインしました" and return
     end
 
-    # 2) 認証レコードは無いが同じメールのユーザーがいる → 既存ユーザーに紐付け
     if email && (user = User.where("lower(email) = ?", email).first)
-      user.authentications.find_or_create_by!(provider: provider, uid: uid)
+      user.authentications.find_or_create_by!(provider: prov, uid: uid)
       reset_session
       session[:user_id] = user.id
-      redirect_to root_path, notice: "#{display}をあなたのアカウントに連携しました" and return
+      user.update_column(:last_login_at, Time.current)
+      redirect_to root_path, notice: "#{provider_label(prov)}をあなたのアカウントに連携しました" and return
     end
 
-    # 3) どちらも無ければ新規作成（パスワードはダミー）
+    # 新規ユーザー作成（ダミーパスワード）
     user = User.create!(
       name:     name,
-      email:    email,  # 一部プロバイダは nil の可能性あり
+      email:    email,
       password: SecureRandom.urlsafe_base64(24)
     )
-    user.authentications.create!(provider: provider, uid: uid)
-
+    user.authentications.create!(provider: prov, uid: uid)
     reset_session
     session[:user_id] = user.id
-    redirect_to root_path, notice: "#{display}で新規登録しました"
+    user.update_column(:last_login_at, Time.current)
+    redirect_to root_path, notice: "#{provider_label(prov)}で新規登録しました"
 
   rescue => e
     Rails.logger.error("[OmniAuth #{e.class}] #{e.message}\n#{e.backtrace&.first}")

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,49 @@
+# app/controllers/profiles_controller.rb
+class ProfilesController < ApplicationController
+  before_action :require_login!
+
+  def show
+    @user = current_user
+  end
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+
+    case params[:commit]
+    when "プロフィール更新"
+      if @user.update(profile_params)
+        redirect_to profile_path, notice: "プロフィールを更新しました"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+
+    when "パスワード更新"
+      unless @user.authenticate(params.dig(:user, :current_password).to_s)
+        @user.errors.add(:current_password, "現在のパスワードが違います")
+        flash.now[:alert] = "現在のパスワードが違います"
+        return render :edit, status: :unprocessable_entity
+      end
+      if @user.update(password_params)
+        redirect_to profile_path, notice: "パスワードを更新しました"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    else
+      head :bad_request
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:user).permit(:name)
+  end
+
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,6 +20,7 @@ class SessionsController < ApplicationController
     if user&.uses_password? && user&.authenticate(params[:password])
       reset_session
       session[:user_id] = user.id
+      user.update_column(:last_login_at, Time.current)
       redirect_to root_path, notice: "ログインしました"
     else
       flash.now[:alert] = "メールまたはパスワードが正しくありません"

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/views/profiles/_oauth_link_buttons.html.erb
+++ b/app/views/profiles/_oauth_link_buttons.html.erb
@@ -1,0 +1,20 @@
+<!-- app/views/profiles/_oauth_link_buttons.html.erb -->
+<div class="space-y-2">
+  <% unless current_user.authentications.exists?(provider: "google_oauth2") %>
+    <%= link_to "/auth/google_oauth2?link=1",
+        class: "inline-flex w-full items-center justify-center gap-2 rounded-xl bg-white ring-1 ring-slate-200 px-4 py-2 hover:bg-slate-50" do %>
+      <span class="font-medium text-slate-700">Google に接続</span>
+    <% end %>
+  <% else %>
+    <span class="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200">Google 接続済み</span>
+  <% end %>
+
+  <% unless current_user.authentications.exists?(provider: "github") %>
+    <%= link_to "/auth/github?link=1",
+        class: "inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" do %>
+      <span class="font-medium">GitHub に接続</span>
+    <% end %>
+  <% else %>
+    <span class="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200">GitHub 接続済み</span>
+  <% end %>
+</div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,58 @@
+<!-- app/views/profiles/edit.html.erb -->
+<% content_for :title, "プロフィール編集" %>
+<h1 class="text-xl font-semibold mb-4">プロフィール編集</h1>
+
+<div class="mx-auto w-full max-w-2xl space-y-8">
+
+  <!-- セクション1：プロフィール -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">プロフィール</h2>
+    <div class="mt-2 rounded-xl bg-white ring-1 ring-slate-200 p-4">
+      <%= form_with model: current_user, url: profile_path, method: :patch, local: true do |f| %>
+        <div class="space-y-3">
+          <div>
+            <%= f.label :name, "表示名", class: "block text-sm mb-1" %>
+            <%= f.text_field :name, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+          </div>
+          <div class="pt-2">
+            <%= f.submit "プロフィール更新", class: "rounded-md bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-800" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <!-- セクション2：パスワード -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">パスワード変更</h2>
+    <div class="mt-2 rounded-xl bg-white ring-1 ring-slate-200 p-4">
+      <%= form_with model: current_user, url: profile_path, method: :patch, local: true do |f| %>
+        <div class="space-y-3">
+          <div>
+            <%= f.label :current_password, "現在のパスワード", class: "block text-sm mb-1" %>
+            <%= f.password_field :current_password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
+          </div>
+          <div>
+            <%= f.label :password, "新しいパスワード", class: "block text-sm mb-1" %>
+            <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
+          </div>
+          <div>
+            <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm mb-1" %>
+            <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
+          </div>
+          <div class="pt-2">
+            <%= f.submit "パスワード更新", class: "rounded-md bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-800" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <!-- セクション3：外部連携 -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">外部連携</h2>
+    <div class="mt-2 rounded-xl bg-white ring-1 ring-slate-200 p-4">
+      <%= render "profiles/oauth_link_buttons" %>
+    </div>
+  </section>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,44 @@
+<!-- app/views/profiles/show.html.erb -->
+<% content_for :title, "プロフィール" %>
+
+<div class="mx-auto w-full max-w-2xl space-y-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-xl font-semibold text-slate-900">プロフィール</h1>
+    <%= link_to "編集", edit_profile_path,
+          class: "rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" %>
+  </div>
+
+  <div class="rounded-xl bg-white ring-1 ring-slate-200 divide-y divide-slate-100">
+    <div class="grid grid-cols-3 gap-4 px-4 py-3">
+      <div class="text-sm text-slate-500">ユーザー名</div>
+      <div class="col-span-2"><%= current_user.name %></div>
+    </div>
+    <div class="grid grid-cols-3 gap-4 px-4 py-3">
+      <div class="text-sm text-slate-500">メール</div>
+      <div class="col-span-2"><%= current_user.email %></div>
+    </div>
+    <div class="grid grid-cols-3 gap-4 px-4 py-3">
+      <div class="text-sm text-slate-500">外部連携</div>
+      <div class="col-span-2 flex flex-wrap gap-2">
+        <% if current_user.authentications.exists?(provider: "google_oauth2") %>
+          <span class="rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200">Google 接続済み</span>
+        <% else %>
+          <span class="rounded-full bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600 ring-1 ring-slate-200">Google 未接続</span>
+        <% end %>
+        <% if current_user.authentications.exists?(provider: "github") %>
+          <span class="rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200">GitHub 接続済み</span>
+        <% else %>
+          <span class="rounded-full bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600 ring-1 ring-slate-200">GitHub 未接続</span>
+        <% end %>
+      </div>
+    </div>
+    <div class="grid grid-cols-3 gap-4 px-4 py-3">
+      <div class="text-sm text-slate-500">登録日</div>
+      <div class="col-span-2"><%= l current_user.created_at, format: :ymd_hm %></div>
+    </div>
+    <div class="grid grid-cols-3 gap-4 px-4 py-3">
+      <div class="text-sm text-slate-500">最終ログイン</div>
+      <div class="col-span-2"><%= current_user.last_login_at ? l(current_user.last_login_at, format: :ymd_hm) : "-" %></div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_modal_panel.html.erb
+++ b/app/views/shared/_modal_panel.html.erb
@@ -15,20 +15,18 @@
        class="relative mx-auto w-11/12 max-w-lg rounded-2xl bg-white p-8 shadow-lg text-slate-900
               max-h-[calc(100vh-2rem)] md:max-h-[calc(100vh-3.5rem)] lg:max-h-none overflow-y-auto">
 
-    <!-- タイトル + × -->
-    <div class="mb-4 flex items-center justify-center">
-      <h2 id="user-menu-title" class="text-xl font-semibold">メニュー</h2>
-      <button class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
-              data-action="click->modal#close" aria-label="閉じる">
-        <%= heroicon "x-mark", variant: :solid, options: { class: "w-6 h-6" } %>
-      </button>
-    </div>
+    <!-- タイトルは削除、×だけ残す -->
+    <button class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
+            data-action="click->modal#close" aria-label="閉じる">
+      <%= heroicon "x-mark", variant: :solid, options: { class: "w-6 h-6" } %>
+    </button>
 
     <%# ================= PC用（lg以上だけ表示） ================= %>
     <div class="hidden lg:block">
       <% if logged_in? %>
         <ul class="space-y-0 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
           <li><%= link_to "アプリの使い方",   help_path,     class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "ユーザープロフィール", profile_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "お問い合わせ",     contact_path,  class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "利用規約",         terms_path,    class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "プライバシーポリシー", privacy_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
@@ -64,14 +62,15 @@
     <div class="lg:hidden">
       <% if logged_in? %>
         <ul class="space-y-0 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
-          <li><%= link_to "Code Editor",  editor_path,       class: "block py-3 text-center hover:text-[#CC0000]" %></li>
-          <li><%= link_to "Rails Books",  books_path,        class: "block py-3 text-center hover:text-[#CC0000]" %></li>
-          <li><%= link_to "PreCode",      pre_codes_path,    class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "Code Editor",  editor_path,         class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "Rails Books",  books_path,          class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "PreCode",      pre_codes_path,      class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "Code Library", code_libraries_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
         </ul>
 
         <ul class="mt-2 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
           <li><%= link_to "アプリの使い方",   help_path,     class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "ユーザープロフィール", profile_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "お問い合わせ",     contact_path,  class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "利用規約",         terms_path,    class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "プライバシーポリシー", privacy_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
@@ -89,14 +88,15 @@
         </ul>
 
         <ul class="mt-2 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
-          <li><%= link_to "Code Editor",  editor_path,       class: "block py-3 text-center hover:text-[#CC0000]" %></li>
-          <li><%= link_to "Rails Books",  books_path,        class: "block py-3 text-center hover:text-[#CC0000]" %></li>
-          <li><%= link_to "PreCode",      pre_codes_path,    class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "Code Editor",  editor_path,         class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "Rails Books",  books_path,          class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "PreCode",      pre_codes_path,      class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "Code Library", code_libraries_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
         </ul>
 
         <ul class="mt-2 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
           <li><%= link_to "アプリの使い方",   help_path,     class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "ユーザープロフィール", profile_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "お問い合わせ",     contact_path,  class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "利用規約",         terms_path,    class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "プライバシーポリシー", privacy_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
       default: "%Y/%m/%d"
       short:   "%m/%d"
       long:    "%Y年%-m月%-d日(%a)"
+      ymd_hm: "%Y/%m/%d %H:%M"
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
@@ -44,6 +45,8 @@ ja:
       book_section:
         create: "作成する"
         update: "更新する"
+      user:
+        update: "更新"
   errors:
     messages:
       blank: "を入力してください"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   resource  :session, only: %i[new create destroy]     # ログイン/ログアウト
   resources :password_resets, only: %i[new create edit update]  # パス再設定用
 
+  # ユーザープロフィール
+  resource :profile, only: %i[show edit update]
+
   # PreCode機能
   concern :paginatable do
     # /pre_codes/page/2 → index の2ページ目に到達
@@ -44,11 +47,6 @@ Rails.application.routes.draw do
 
   # 管理画面
   namespace :admin do
-    get "pre_codes/index"
-    get "pre_codes/show"
-    get "pre_codes/edit"
-    get "pre_codes/update"
-    get "pre_codes/destroy"
     root "dashboards#index"
 
     resource  :session,   only: %i[new create destroy]

--- a/db/migrate/20250924023524_add_last_login_at_to_users.rb
+++ b/db/migrate/20250924023524_add_last_login_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastLoginAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_login_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_23_181851) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_24_023524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -134,6 +134,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_23_181851) do
     t.boolean "editor", default: false, null: false
     t.datetime "banned_at"
     t.string "ban_reason"
+    t.datetime "last_login_at"
     t.index "lower((email)::text)", name: "index_users_on_lower_email_unique", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token_unique", unique: true
   end

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe "OmniAuth", type: :request do
         }.to change(User, :count).by(0).and change(Authentication, :count).by(0)
         expect(response).to redirect_to(root_path)
       end
+
+      it "ログイン成功時に last_login_at が更新される" do
+        mock_omniauth(provider: "google_oauth2", uid: "U-1", email: auth.user.email)
+
+        get omni_auth_callback_path(provider: "google_oauth2")
+
+        expect(response).to redirect_to(root_path)
+        expect(auth.user.reload.last_login_at).to be_present
+      end
     end
 
     context "既存ユーザーとメールが一致する場合は認証が紐付く" do
@@ -43,6 +52,15 @@ RSpec.describe "OmniAuth", type: :request do
         }.to change(Authentication, :count).by(1)
         expect(Authentication.last.user_id).to eq(user.id)
         expect(response).to redirect_to(root_path)
+      end
+
+      it "紐付け成功時に last_login_at が更新される" do
+        mock_omniauth(provider: "google_oauth2", uid: "NEW-UID", email: user.email)
+
+        get omni_auth_callback_path(provider: "google_oauth2")
+
+        expect(response).to redirect_to(root_path)
+        expect(user.reload.last_login_at).to be_present
       end
     end
 

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -1,0 +1,47 @@
+# spec/requests/profiles_spec.rb
+require "rails_helper"
+
+RSpec.describe "Profiles", type: :request do
+  let(:user) { create(:user, password: "secret123", password_confirmation: "secret123") }
+
+  before { sign_in user }
+
+  describe "GET /profile" do
+    it "表示できる" do
+      get profile_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(user.email)
+    end
+  end
+
+  describe "GET /profile/edit" do
+    it { get edit_profile_path; expect(response).to have_http_status(:ok) }
+  end
+
+  describe "PATCH /profile (プロフィール更新)" do
+    it "名前を更新できる" do
+      patch profile_path, params: { user: { name: "New Name" }, commit: "プロフィール更新" }
+      expect(response).to redirect_to(profile_path)
+      expect(user.reload.name).to eq("New Name")
+    end
+  end
+
+  describe "PATCH /profile (パスワード更新)" do
+    it "現在PWが一致すれば更新できる" do
+      patch profile_path, params: {
+        user: { current_password: "secret123", password: "newpass1", password_confirmation: "newpass1" },
+        commit: "パスワード更新"
+      }
+      expect(response).to redirect_to(profile_path)
+    end
+
+    it "現在PWが違うと422" do
+      patch profile_path, params: {
+        user: { current_password: "wrong", password: "newpass1", password_confirmation: "newpass1" },
+        commit: "パスワード更新"
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("現在のパスワードが違います")
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe "Sessions", type: :request do
       expect(session[:user_id]).to be_blank
     end
 
+    it "ログイン成功時に last_login_at が更新される" do
+      expect(user.last_login_at).to be_nil
+
+      post session_path, params: { email: "a@example.com", password: "secret123" }
+
+      expect(response).to redirect_to(root_path)
+      expect(user.reload.last_login_at).to be_present
+    end
+
     context "BAN中ユーザーの場合" do
       let!(:banned) do
         # 既存Factoryに :banned trait を追加済みなのでそれを利用


### PR DESCRIPTION
### 概要
ユーザープロフィール画面を追加し、名前・パスワード更新や外部アカウント接続、最終ログイン記録を実装した。

**作業内容**

- ProfilesController を新規作成し、プロフィール表示・編集・更新を実装（名前更新、パスワード更新）
- SessionsController / OmniAuthController に last_login_at の更新処理を追加し、最終ログイン日時を記録
- プロフィール編集画面に外部連携（Google / GitHub）ボタンを設置し、メール一致を条件に接続を許可
- プロフィール画面のビューを作成し、ユーザー名・メール・外部連携・登録日・最終ログインを表示
- モーダルに「ユーザープロフィール」へのリンクを追加し、スマホ表示時のレイアウトを調整