### PR TITLE
ブックマーク機能を追加：モデル/コントローラ/TurboStream/一覧フィルタを実装し、300件上限と自分データ禁止を含めた

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,40 @@
+# app/controllers/bookmarks_controller.rb
+class BookmarksController < ApplicationController
+  before_action :require_login!
+  before_action :set_pre_code, only: :create
+
+  def create
+    return head :forbidden if @pre_code.user_id == current_user.id
+
+    if current_user.bookmarks.count >= 300
+      redirect_back fallback_location: code_libraries_path,
+                    alert: I18n.t("bookmarks.limit_reached") and return
+    end
+
+    current_user.bookmarks.create!(pre_code: @pre_code)
+    @pre_code.reload
+    respond_to do |f|
+      f.turbo_stream
+      f.html { redirect_back fallback_location: code_libraries_path }
+    end
+  rescue ActiveRecord::RecordInvalid
+    head :ok
+  end
+
+  def destroy
+    bookmark = current_user.bookmarks.find(params[:id])
+    @pre_code = bookmark.pre_code
+    bookmark.destroy!
+    @pre_code.reload
+    respond_to do |f|
+      f.turbo_stream
+      f.html { redirect_back fallback_location: code_libraries_path }
+    end
+  end
+
+  private
+
+  def set_pre_code
+    @pre_code = PreCode.find(params[:pre_code_id])
+  end
+end

--- a/app/controllers/code_libraries_controller.rb
+++ b/app/controllers/code_libraries_controller.rb
@@ -4,9 +4,11 @@ class CodeLibrariesController < ApplicationController
   def index
     base = PreCode.except_user(current_user&.id)
     @q = base.ransack(params[:q])
-
-    # 検索結果
     rel = @q.result
+
+    if params[:only_bookmarked].present? && logged_in?
+      rel = rel.joins(:bookmarks).where(bookmarks: { user_id: current_user.id })
+    end
 
     # ソートキー（popular / used / newest）。デフォルト popular
     sort_key = params[:sort].presence || "popular"

--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,0 +1,2 @@
+module BookmarksHelper
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,7 @@
+# app/models/bookmark.rb
+class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :pre_code
+
+  validates :user_id, uniqueness: { scope: :pre_code_id }
+end

--- a/app/models/pre_code.rb
+++ b/app/models/pre_code.rb
@@ -5,6 +5,7 @@ class PreCode < ApplicationRecord
   has_many :used_codes, dependent: :destroy
   has_many :pre_code_taggings, dependent: :destroy
   has_many :tags, through: :pre_code_taggings
+  has_many :bookmarks, dependent: :destroy
 
   validates :title,
             presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   has_many :likes,      dependent: :destroy
   has_many :used_codes, dependent: :destroy
   has_many :authentications, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmarked_pre_codes, through: :bookmarks, source: :pre_code
 
   # bcrypt
   has_secure_password validations: false
@@ -150,6 +152,17 @@ class User < ApplicationRecord
   # Rememberの有効期限（30日）
   def remember_expired?(ttl: 30.days)
     remember_created_at.blank? || remember_created_at < ttl.ago
+  end
+
+  # ---------- ブックマーク設定 ----------
+  # その PreCode をブックマーク済みか？
+  def bookmarked?(pre_code)
+    bookmarks.exists?(pre_code_id: pre_code.id)
+  end
+
+  # その PreCode のブックマークオブジェクトを返す（なければ nil）
+  def bookmark_for(pre_code)
+    bookmarks.find_by(pre_code_id: pre_code.id)
   end
 
   private

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%# app/views/bookmarks/create.turbo_stream.erb %>
+<%= turbo_stream.replace dom_id(@pre_code, :actions) do %>
+  <%= render "code_libraries/actions",
+      pre_code: @pre_code,
+      current_like: (logged_in? ? @pre_code.likes.find_by(user_id: current_user.id) : nil),
+      current_bookmark: (logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id) : nil) %>
+<% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%# app/views/bookmarks/destroy.turbo_stream.erb %>
+<%= turbo_stream.replace dom_id(@pre_code, :actions) do %>
+  <%= render "code_libraries/actions",
+      pre_code: @pre_code,
+      current_like: (logged_in? ? @pre_code.likes.find_by(user_id: current_user.id) : nil),
+      current_bookmark: (logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id) : nil) %>
+<% end %>

--- a/app/views/code_libraries/_actions.html.erb
+++ b/app/views/code_libraries/_actions.html.erb
@@ -2,21 +2,41 @@
 <%# locals: pre_code:, current_like: %>
 <div id="<%= dom_id(pre_code, :actions) %>" class="flex gap-2">
   <% if logged_in? %>
+    <%# === いいね === %>
     <% if current_like %>
       <%= button_to like_path(current_like),
-            method: :delete,
-            form:   { data: { turbo_stream: true } },
-            class:  "px-3 py-1 rounded bg-rose-600 text-white inline-flex items-center gap-1" do %>
-        <%= heroicon "heart", variant: :solid,  options: { class: "w-4 h-4" } %>
+          method: :delete,
+          form: { data: { turbo_stream: true } },
+          class: "px-3 py-1 rounded bg-rose-600 text-white inline-flex items-center gap-1" do %>
+        <%= heroicon "heart", variant: :solid, options: { class: "w-4 h-4" } %>
         <%= pre_code.like_count %>
       <% end %>
     <% else %>
       <%= button_to likes_path(pre_code_id: pre_code.id),
-            method: :post,
-            form:   { data: { turbo_stream: true } },
-            class:  "px-3 py-1 rounded ring-1 ring-slate-300 inline-flex items-center gap-1" do %>
+          method: :post,
+          form: { data: { turbo_stream: true } },
+          class: "px-3 py-1 rounded ring-1 ring-slate-300 inline-flex items-center gap-1" do %>
         <%= heroicon "heart", variant: :outline, options: { class: "w-4 h-4" } %>
         <%= pre_code.like_count %>
+      <% end %>
+    <% end %>
+
+    <%# === ブックマーク === %>
+    <% if current_bookmark %>
+      <%= button_to bookmark_path(current_bookmark),
+          method: :delete,
+          form: { data: { turbo_stream: true } },
+          class: "px-3 py-1 rounded bg-blue-600 text-white inline-flex items-center gap-1" do %>
+        <%= heroicon "bookmark", variant: :solid, options: { class: "w-4 h-4" } %>
+        保存済み
+      <% end %>
+    <% else %>
+      <%= button_to bookmarks_path(pre_code_id: pre_code.id),
+          method: :post,
+          form: { data: { turbo_stream: true } },
+          class: "px-3 py-1 rounded ring-1 ring-slate-300 inline-flex items-center gap-1" do %>
+        <%= heroicon "bookmark", variant: :outline, options: { class: "w-4 h-4" } %>
+        ブックマーク
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -34,12 +34,20 @@
       <% end %>
     </div>
 
-    <%# ← ここが追加：Code Library 向けのタグ検索（送り先を指定） %>
+    <%# Code Library 向けのタグ検索（送り先を指定） %>
     <div class="flex mt-2 justify-end">
       <%= render "shared/tag_filter", url: code_libraries_path %>
     </div>
 
-    <div class="flex mt-2 justify-end">
+    <div class="flex mt-2 justify-end gap-2">
+      <% keep = request.query_parameters.except(:only_bookmarked, :page) %>
+      <% on = params[:only_bookmarked].present? %>
+      <% url = on ? url_for(keep) : url_for(keep.merge(only_bookmarked: 1)) %>
+
+      <%= link_to (on ? "ブックマークのみ：ON" : "ブックマークのみ"),
+            url,
+            class: "px-3 py-2 rounded #{on ? 'bg-blue-600 text-white' : 'ring-1 ring-slate-300'}" %>
+
       <%= link_to "使い方", help_path,
             class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
     </div>
@@ -81,7 +89,8 @@
           <div class="pointer-events-auto z-20">
             <%= render "actions",
                   pre_code: pc,
-                  current_like: (logged_in? ? pc.likes.find_by(user_id: current_user.id) : nil) %>
+                  current_like: (logged_in? ? pc.likes.find_by(user_id: current_user.id) : nil),
+                  current_bookmark: (logged_in? ? pc.bookmarks.find_by(user_id: current_user.id) : nil) %>
           </div>
         </div>
       </li>

--- a/app/views/code_libraries/show.html.erb
+++ b/app/views/code_libraries/show.html.erb
@@ -5,16 +5,29 @@
 
 <% content_for :title, @pre_code.title %>
 
+<%# 先に一度だけ計算して使い回す %>
+<% current_like      = logged_in? ? @pre_code.likes.find_by(user_id: current_user.id)       : nil %>
+<% current_bookmark  = logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id)   : nil %>
+
 <div class="mx-auto w-full max-w-2xl space-y-8">
-  <!-- 登録名 -->
-  <section>
+
+  <%# ===== 右上：いいね & ブックマーク ===== %>
+  <div class="flex justify-end">
+    <%= render "code_libraries/actions",
+          pre_code: @pre_code,
+          current_like: current_like,
+          current_bookmark: current_bookmark %>
+  </div>
+
+  <%# ===== 登録名 ===== %>
+  <section class="-mt-4">
     <h2 class="text-sm font-semibold tracking-wider text-slate-500">登録名</h2>
     <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3">
       <p class="text-base"><%= @pre_code.title %></p>
     </div>
   </section>
 
-  <!-- タグ -->
+  <%# ===== タグ ===== %>
   <section>
     <h2 class="text-sm font-semibold tracking-wider text-slate-500">タグ</h2>
     <div class="mt-1">
@@ -22,7 +35,7 @@
     </div>
   </section>
 
-  <!-- コードの説明 -->
+  <%# ===== 説明 ===== %>
   <section>
     <h2 class="text-sm font-semibold tracking-wider text-slate-500">コードの説明</h2>
     <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3">
@@ -30,7 +43,7 @@
     </div>
   </section>
 
-  <!-- 登録コード + 最終更新 -->
+  <%# ===== 登録コード ===== %>
   <section>
     <div class="flex items-baseline justify-between">
       <h2 class="text-sm font-semibold tracking-wider text-slate-500">登録コード</h2>
@@ -47,24 +60,15 @@
     </div>
   </section>
 
-  <!-- 利用ボタン ＋ いいねボタン -->
-  <section class="-mt-2">
-    <div class="grid grid-cols-3 items-center">
-      <div class="col-start-2 justify-self-center">
-        <%= button_to "このデータを利用する",
-              used_codes_path(pre_code_id: @pre_code.id,
-                              redirect: editor_path(pre_code_id: @pre_code.id)),
-              method: :post,
-              form: { data: { turbo: false } },
-              class: "inline-flex justify-center w-50 sm:w-64 md:w-80 lg:w-96
-                      bg-[#CC0000] text-white px-4 py-2 rounded
-                      hover:bg-[#BB0000] active:bg-[#AA0000]" %>
-      </div>
-
-      <div class="col-start-3 justify-self-end">
-        <% current_like = logged_in? ? @pre_code.likes.find_by(user_id: current_user.id) : nil %>
-        <%= render "actions", pre_code: @pre_code, current_like: current_like %>
-      </div>
-    </div>
-  </section>
+  <%# ===== 最下部：中央に「このデータを利用する」 ===== %>
+  <div class="-mt-2 text-center">
+    <%= button_to "このデータを利用する",
+          used_codes_path(pre_code_id: @pre_code.id,
+                          redirect: editor_path(pre_code_id: @pre_code.id)),
+          method: :post,
+          form: { data: { turbo: false } },
+          class: "inline-flex justify-center w-50 sm:w-64 md:w-80 lg:w-96
+                  bg-[#CC0000] text-white px-4 py-2 rounded
+                  hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+  </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,3 +50,5 @@ ja:
   errors:
     messages:
       blank: "を入力してください"
+  bookmarks:
+    limit_reached: "300件以上のブックマーク登録はできません"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
     post :revoke_remember
   end
 
+  # ブックマーク機能
+  resources :bookmarks, only: %i[create destroy]
+
   # PreCode機能
   concern :paginatable do
     # /pre_codes/page/2 → index の2ページ目に到達

--- a/db/migrate/20250925034231_create_bookmarks.rb
+++ b/db/migrate/20250925034231_create_bookmarks.rb
@@ -1,0 +1,13 @@
+class CreateBookmarks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user,     null: false, foreign_key: true
+      t.references :pre_code, null: false, foreign_key: { on_delete: :cascade }
+      t.timestamps
+    end
+
+    # 複合ユニーク（同じ組み合わせを防ぐ）
+    add_index :bookmarks, [ :user_id, :pre_code_id ], unique: true,
+              name: "index_bookmarks_on_user_id_and_pre_code_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_24_175444) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_25_034231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -63,6 +63,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_24_175444) do
     t.datetime "updated_at", null: false
     t.index ["book_id", "position"], name: "index_book_sections_on_book_id_and_position", unique: true
     t.index ["book_id"], name: "index_book_sections_on_book_id"
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "pre_code_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pre_code_id"], name: "index_bookmarks_on_pre_code_id"
+    t.index ["user_id", "pre_code_id"], name: "index_bookmarks_on_user_id_and_pre_code_id", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "books", force: :cascade do |t|
@@ -168,6 +178,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_24_175444) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authentications", "users", on_delete: :cascade
   add_foreign_key "book_sections", "books"
+  add_foreign_key "bookmarks", "pre_codes", on_delete: :cascade
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "likes", "pre_codes"
   add_foreign_key "likes", "users"
   add_foreign_key "pre_code_taggings", "pre_codes", on_delete: :cascade

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,0 +1,7 @@
+# spec/factories/bookmarks.rb
+FactoryBot.define do
+  factory :bookmark do
+    association :user
+    association :pre_code
+  end
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,0 +1,10 @@
+# spec/models/bookmark_spec.rb
+require "rails_helper"
+
+RSpec.describe Bookmark, type: :model do
+  it "user と pre_code の組が一意" do
+    b = create(:bookmark)
+    expect { create(:bookmark, user: b.user, pre_code: b.pre_code) }
+      .to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/requests/bookmarks_spec.rb
+++ b/spec/requests/bookmarks_spec.rb
@@ -1,0 +1,42 @@
+# spec/requests/bookmarks_spec.rb
+require "rails_helper"
+
+RSpec.describe "Bookmarks", type: :request do
+  let(:user) { create(:user) }
+  let(:other) { create(:user) }
+  let(:pc) { create(:pre_code, user: other) }
+
+  before { sign_in user }
+
+  it "作成できる" do
+    expect {
+      post bookmarks_path, params: { pre_code_id: pc.id }
+    }.to change(Bookmark, :count).by(1)
+  end
+
+  it "削除できる" do
+    b = create(:bookmark, user:, pre_code: pc)
+    expect {
+      delete bookmark_path(b)
+    }.to change(Bookmark, :count).by(-1)
+  end
+
+  it "自分のPreCodeはブクマ不可（403）" do
+    mine = create(:pre_code, user:)
+    post bookmarks_path, params: { pre_code_id: mine.id }
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "上限300件を超えるとフラッシュで拒否" do
+    create_list(:bookmark, 300, user:)
+    post bookmarks_path, params: { pre_code_id: pc.id }
+    expect(flash[:alert]).to include("300件以上")
+  end
+
+  it "一覧で only_bookmarked=1 を付けると自分のブクマだけに絞られる" do
+    bookmarked = create(:pre_code, user: other)
+    create(:bookmark, user:, pre_code: bookmarked)
+    get code_libraries_path, params: { only_bookmarked: 1 }
+    expect(response.body).to include(bookmarked.title)
+  end
+end


### PR DESCRIPTION
### 概要
Code Library にブックマーク機能を追加し、一覧/詳細のトグル・絞り込み・上限管理まで実装した。

**作業内容**

- bookmarks テーブルと Bookmark モデルを追加（FK/複合ユニーク、PreCode 削除時の CASCADE、バリデーション）
- BookmarksController を実装（作成/削除、Turbo Stream でのUI更新、自分のPreCode禁止・300件上限の制御）
- 一覧/詳細のアクション領域にブックマークボタンを追加し、dom_id(pre_code, :actions) でいいねと共通置換
- CodeLibrary 一覧に「ブックマークのみ」フィルタを追加（検索/ソート/ページ送りのクエリ維持）
- RSpec を追加（モデル一意制約、作成・削除・自分データ禁止・上限300・一覧フィルタの動作確認）