### PR TITLE
テキスト検索のオートコンプリートを追加：/search/suggest と Stimulus で一覧検索の候補提示を実装

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,0 +1,43 @@
+# app/controllers/searches_controller.rb
+class SearchesController < ApplicationController
+  # 未ログインでもOK
+  def suggest
+    q = params[:q].to_s.strip
+    return render json: { items: [], q: q } if q.blank?
+
+    # 前方一致（ILIKE prefix%）＋人気セカンダリ
+    rel = PreCode
+            .select(:id, :title, :description, :like_count, :use_count, :created_at)
+            .where("title ILIKE ? OR description ILIKE ?", "#{q}%", "#{q}%")
+            .order(like_count: :desc, use_count: :desc, created_at: :desc)
+            .limit(24) # 一旦多めに取ってから 8 件に整形
+
+    qi = q.downcase
+    items = []
+
+    rel.each do |pc|
+      if pc.title.present? && pc.title.downcase.start_with?(qi)
+        items << { type: "title", label: pc.title,
+                    highlighted: highlight(pc.title, q), query: pc.title }
+      end
+      if pc.description.present? && pc.description.downcase.start_with?(qi)
+        # 先頭語だけを検索語に使う（説明全体は長すぎるため）
+        first_token =
+          pc.description.to_s.split(/[\s 、。，．,。]/).first.presence || q
+        items << { type: "desc", label: pc.description.truncate(80),
+                    highlighted: highlight(pc.description, q, 80), query: first_token }
+      end
+      break if items.size >= 8
+    end
+
+    render json: { items:, q: q }
+  end
+
+  private
+
+  # マッチ箇所を <b> で強調（大小無視）
+  def highlight(text, q, limit = nil)
+    t = limit ? text.truncate(limit) : text
+    t.gsub(/(#{Regexp.escape(q)})/i, '<b>\1</b>')
+  end
+end

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -1,0 +1,2 @@
+module SearchesHelper
+end

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,216 @@
+// app/javascript/controllers/autocomplete_controller.js
+// 検索入力にアタッチして、200ms デバウンス → /search/suggest を叩く。
+// 1秒5回のレート制限、同一クエリ60秒メモリキャッシュ、矢印/Enter/ESC 対応。
+
+import { Controller } from "@hotwired/stimulus"
+
+const DEBOUNCE_MS = 200
+const MAX_RPS = 5          // 1秒あたり最大5回
+const CACHE_TTL_MS = 60_000
+
+export default class extends Controller {
+  static targets = ["input", "panel"]
+  static values = {
+    listUrl: String,   // 例：/code_libraries か /pre_codes
+    sort: String       // 現在の sort 値（維持する）
+  }
+
+  connect() {
+    this._cache = new Map() // q -> {ts, items}
+    this._timer = null
+    this._activeIndex = -1
+    this._lastTs = []
+    this._bindEvents()
+    this.formEl = this.inputTarget.closest("form")
+    if (this.formEl) {
+      this._formSubmitHandler = (e) => {
+        const open = !this.panelTarget.classList.contains("hidden")
+        if (open) e.preventDefault()
+      }
+      this.formEl.addEventListener("submit", this._formSubmitHandler)
+    }
+  }
+
+  disconnect() {
+    this._unbindEvents()
+    if (this.formEl) this.formEl.removeEventListener("submit", this._formSubmitHandler)
+  }
+
+  _bindEvents() {
+    this.keydownHandler = (e) => this.onKeydown(e)
+    this.inputTarget.addEventListener("keydown", this.keydownHandler)
+  }
+
+  _unbindEvents() {
+    this.inputTarget.removeEventListener("keydown", this.keydownHandler)
+  }
+
+  // input -> debounce
+  onInput() {
+    clearTimeout(this._timer)
+    this._timer = setTimeout(() => this.fetchSuggest(), DEBOUNCE_MS)
+  }
+
+  onFocus() {
+    if (this.inputTarget.value.trim() !== "") this.fetchSuggest()
+  }
+
+  onBlur(e) {
+    // 少し遅らせて click を拾わせる
+    setTimeout(() => this.hidePanel(), 120)
+  }
+
+  onKeydown(e) {
+    const open = !this.panelTarget.classList.contains("hidden")
+    if (!open && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+      this.fetchSuggest()
+      return
+    }
+
+    if (!open) return
+
+    const items = this.panelTarget.querySelectorAll("[role='option']")
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      this._activeIndex = Math.min(items.length - 1, this._activeIndex + 1)
+      this._applyActive(items)
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      this._activeIndex = Math.max(0, this._activeIndex - 1)
+      this._applyActive(items)
+    } else if (e.key === "Enter") {
+      e.preventDefault()
+      if (this._activeIndex < 0) this._activeIndex = 0
+      if (items[this._activeIndex]) {
+        // click だと onBlur タイミング次第で不安定なので直接遷移
+        const list = this.panelTarget.querySelectorAll("[role='option']")
+        const selected = list[this._activeIndex]
+        if (selected) {
+          const idx = Number(selected.dataset.index)
+          const chosen = this._lastItems?.[idx] || null
+          const q = chosen?.query || this.inputTarget.value.trim()
+          this.inputTarget.value = q
+          this.navigateWithQuery(q)
+        }
+      } else {
+        // 候補がなくても通常検索に遷移
+        this.navigateWithQuery(this.inputTarget.value.trim())
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault()
+      this.hidePanel()
+    }
+  }
+
+  _applyActive(items) {
+    items.forEach(el => el.classList.remove("bg-slate-100"))
+    if (this._activeIndex >= 0 && items[this._activeIndex]) {
+      items[this._activeIndex].classList.add("bg-slate-100")
+      items[this._activeIndex].scrollIntoView({ block: "nearest" })
+    }
+  }
+
+  rateLimited() {
+    const now = Date.now()
+    this._lastTs = this._lastTs.filter(t => now - t < 1000)
+    if (this._lastTs.length >= MAX_RPS) return true
+    this._lastTs.push(now)
+    return false
+  }
+
+  async fetchSuggest() {
+    const q = this.inputTarget.value.trim()
+    if (q === "") { this.hidePanel(); return }
+
+    if (this.rateLimited()) return
+
+    // cache
+    const cached = this._cache.get(q)
+    const now = Date.now()
+    if (cached && (now - cached.ts) < CACHE_TTL_MS) {
+      this.render(cached.items, q)
+      return
+    }
+
+    try {
+      const res = await fetch(`/search/suggest?q=${encodeURIComponent(q)}`, {
+        headers: { "Accept": "application/json" },
+        credentials: "same-origin"
+      })
+      if (!res.ok) throw new Error("bad status")
+      const json = await res.json()
+      this._cache.set(q, { ts: now, items: json.items || [] })
+      this.render(json.items || [], q)
+    } catch (e) {
+      this.renderError()
+    }
+  }
+
+  render(items, q) {
+    this._lastItems = items
+    this._activeIndex = 0
+    if (!items.length) {
+      this.panelTarget.innerHTML = `
+        <div class="p-2 text-sm text-slate-500">候補はありません</div>
+      `
+      this.showPanel()
+      return
+    }
+
+    const rows = items.map((it, idx) => {
+      const badge = it.type === "title" ? "Title" : "Desc"
+      return `
+        <div role="option" data-index="${idx}"
+             class="px-3 py-2 text-sm cursor-pointer flex gap-2 items-start hover:bg-slate-100"
+             aria-selected="false">
+          <span class="shrink-0 mt-0.5 text-xs px-1.5 py-0.5 rounded bg-slate-200 text-slate-700">${badge}</span>
+          <span class="grow leading-5">${it.highlighted}</span>
+        </div>`
+    }).join("")
+
+    this.panelTarget.innerHTML = rows
+    this.panelTarget.querySelectorAll("[role='option']").forEach((el, idx) => {
+      el.addEventListener("mouseenter", () => {
+        this._activeIndex = idx
+        this._applyActive(this.panelTarget.querySelectorAll("[role='option']"))
+      })
+
+      el.addEventListener("mousedown", (e) => {
+        e.preventDefault()
+        this.inputTarget.value = items[idx].query
+        this.navigateWithQuery(items[idx].query || q)
+      })
+    })
+    this.showPanel()
+    this._applyActive(this.panelTarget.querySelectorAll("[role='option']"))
+  }
+
+  renderError() {
+    this.panelTarget.innerHTML = `
+      <div class="p-2 text-sm text-red-600">通信エラー</div>
+    `
+    this.showPanel()
+  }
+
+  showPanel() {
+    this.panelTarget.classList.remove("hidden")
+    this.panelTarget.setAttribute("role", "listbox")
+  }
+
+  hidePanel() {
+    this.panelTarget.classList.add("hidden")
+    this.panelTarget.removeAttribute("role")
+  }
+
+  // 一覧へ遷移：q を渡し、page=1、sort は維持
+  navigateWithQuery(q) {
+    if (!q) return
+    const params = new URLSearchParams()
+    params.set("q[title_or_description_cont]", q)
+    if (this.hasSortValue && this.sortValue) params.set("sort", this.sortValue)
+    params.set("page", "1")
+
+    const to = `${this.listUrlValue}?${params.toString()}`
+    window.location.assign(to)
+  }
+}

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -17,16 +17,26 @@
       <%= search_form_for @q, url: code_libraries_path, method: :get,
             html: { class: "flex gap-2" } do |f| %>
 
-        <%= f.search_field :title_or_description_cont,
-              value: @q.title_or_description_cont,
-              placeholder: "検索（タイトル／説明）",
-              class: "px-3 py-2 rounded ring-1 ring-slate-300 min-w-0 w-40 sm:w-56 md:w-72 lg:w-80" %>
+        <div data-controller="autocomplete"
+            data-autocomplete-list-url-value="<%= code_libraries_path %>"
+            data-autocomplete-sort-value="<%= params[:sort].presence || 'popular' %>">
+          <%= f.search_field :title_or_description_cont,
+                value: @q.title_or_description_cont,
+                placeholder: "検索（タイトル／説明）",
+                class: "px-3 py-2 rounded ring-1 ring-slate-300 min-w-0 w-40 sm:w-56 md:w-72 lg:w-80",
+                data: {
+                  autocomplete_target: "input",
+                  action: "input->autocomplete#onInput focus->autocomplete#onFocus blur->autocomplete#onBlur"
+                } %>
+
+          <!-- dropdown panel -->
+          <div data-autocomplete-target="panel"
+              class="hidden mt-1 w-full max-w-[20rem] rounded border border-slate-200 bg-white shadow-md"></div>
+        </div>
 
         <%= select_tag :sort,
-              options_for_select(
-                [["人気順", "popular"], ["利用数順", "used"], ["新着順", "newest"]],
-                params[:sort].presence || "popular"
-              ),
+              options_for_select([["人気順","popular"],["利用数順","used"],["新着順","newest"]],
+                                params[:sort].presence || "popular"),
               class: "px-3 py-2 rounded ring-1 ring-slate-300" %>
 
         <%= f.submit "検索",

--- a/app/views/pre_codes/index.html.erb
+++ b/app/views/pre_codes/index.html.erb
@@ -16,10 +16,22 @@
     <div class="flex gap-2 justify-end">
       <%= search_form_for @q, url: pre_codes_path, method: :get,
             html: { class: "flex gap-2" } do |f| %>
-        <%= f.search_field :title_or_description_cont,
-              value: @q.title_or_description_cont,
-              placeholder: "検索（タイトル／説明）",
-              class: "px-3 py-2 rounded ring-1 ring-slate-300 w-64" %>
+
+        <div data-controller="autocomplete"
+            data-autocomplete-list-url-value="<%= pre_codes_path %>"
+            data-autocomplete-sort-value="<%= (params[:sort].presence || 'id_desc') %>">
+          <%= f.search_field :title_or_description_cont,
+                value: @q.title_or_description_cont,
+                placeholder: "検索（タイトル／説明）",
+                class: "px-3 py-2 rounded ring-1 ring-slate-300 w-64",
+                data: {
+                  autocomplete_target: "input",
+                  action: "input->autocomplete#onInput focus->autocomplete#onFocus blur->autocomplete#onBlur"
+                } %>
+          <div data-autocomplete-target="panel"
+              class="hidden mt-1 w-full max-w-[20rem] rounded border border-slate-200 bg-white shadow-md"></div>
+        </div>
+
         <%= f.submit "検索",
               class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
       <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,3 +52,6 @@ ja:
       blank: "を入力してください"
   bookmarks:
     limit_reached: "300件以上のブックマーク登録はできません"
+  search:
+    no_items: "候補はありません"
+    error: "通信エラー"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "terms",   to: "static_pages#terms"
   get "privacy", to: "static_pages#privacy"
   get "contact", to: "static_pages#contact"
+  get "/search/suggest", to: "searches#suggest"  # オートコンプリートAPI
   get "tests/index"
 
   # Render のヘルスチェック用

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -1,0 +1,22 @@
+# spec/requests/searches_spec.rb
+require "rails_helper"
+
+RSpec.describe "Searches", type: :request do
+  let!(:pc1) { create(:pre_code, title: "配列操作", description: "配列の基礎", like_count: 3, use_count: 1) }
+  let!(:pc2) { create(:pre_code, title: "文字列操作", description: "文字列の基礎", like_count: 5, use_count: 2) }
+
+  it "q が空なら items は空" do
+    get "/search/suggest", params: { q: "" }
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["items"]).to eq([])
+  end
+
+  it "前方一致で最大8件返す" do
+    get "/search/suggest", params: { q: "配" }
+    expect(response).to have_http_status(:ok)
+    items = JSON.parse(response.body)["items"]
+    expect(items).to be_present
+    expect(items.all? { |i| %w[title desc].include?(i["type"]) }).to be true
+    expect(items.size).to be <= 8
+  end
+end


### PR DESCRIPTION
### 概要
一覧検索に オートコンプリート を追加し、Code Library / My PreCodes の入力体験を高速化した。

**作業内容**

- ルーティングに GET /search/suggest を追加し、SearchesController#suggest を実装（タイトル/説明の前方一致・最大8件・人気順セカンダリ）
- Stimulus autocomplete_controller を新規作成（200msデバウンス、1秒5回レート制限、60秒メモリキャッシュ、↑/↓/Enter/ESC 対応、フォーム submit 抑止）
- 両一覧ビューの検索行に data-* 属性とドロップダウンパネルを組込み、候補選択で q[title_or_description_cont] を付けて page=1 へ遷移（sortは維持）
- 候補表示は Title/Desc バッジ＋マッチ強調（<b>）で視認性を改善、クリック/Enterで入力値へ反映して検索
- リクエストSpecを追加（空クエリで空配列、前方一致・件数制限の検証）