### PR TITLE
PreCodeに問題モードを追加しヒント/解答の入力と詳細トグル表示を実装（answer必須・サニタイズ適用）

### DIFF
--- a/app/controllers/pre_codes_controller.rb
+++ b/app/controllers/pre_codes_controller.rb
@@ -1,3 +1,4 @@
+# app/controllers/pre_codes_controller.rb
 class PreCodesController < ApplicationController
   before_action :require_login!
   before_action :set_pre_code, only: %i[show edit update destroy]
@@ -42,8 +43,7 @@ class PreCodesController < ApplicationController
   def create
     @pre_code = current_user.pre_codes.build(pre_code_params)
     if @pre_code.save
-      # タグ適用（保存後に差分反映）
-      TaggingService.new(@pre_code, current_user: current_user).apply!(params[:tag_names])
+      replace_tags(@pre_code, params[:tag_names]) # ★ タグ付与
       redirect_to @pre_code, notice: "PreCode を作成しました"
     else
       render :new, status: :unprocessable_entity
@@ -56,8 +56,7 @@ class PreCodesController < ApplicationController
   # PATCH/PUT /pre_codes/:id
   def update
     if @pre_code.update(pre_code_params)
-      # タグ適用（保存後に差分反映）
-      TaggingService.new(@pre_code, current_user: current_user).apply!(params[:tag_names])
+      replace_tags(@pre_code, params[:tag_names]) # ★ タグ更新
       redirect_to @pre_code, notice: "PreCode を更新しました"
     else
       render :edit, status: :unprocessable_entity
@@ -79,8 +78,36 @@ class PreCodesController < ApplicationController
 
   # Strong Parameters
   def pre_code_params
-    params.require(:pre_code).permit(:title, :description, :body)
+    attrs = params.require(:pre_code).permit(
+      :title, :description, :body,
+      :hint, :answer, :answer_code
+    )
+
+    # テキストだけサニタイズ（コードはサニタイズしない）
+    sanitizer = if respond_to?(:sanitize_content, true)
+                  method(:sanitize_content)
+    else
+                  ->(html) {
+                    ActionController::Base.helpers.sanitize(
+                      html,
+                      tags: %w[b i em strong code pre br p ul ol li a],
+                      attributes: %w[href]
+                    )
+                  }
+    end
+
+    # キーがある時だけ代入（nil を上書きしない）
+    if attrs.key?(:hint)
+      attrs[:hint] = sanitizer.call(attrs[:hint])
+    end
+    if attrs.key?(:answer)
+      attrs[:answer] = sanitizer.call(attrs[:answer])
+    end
+
+    attrs
   end
+
+  # === タグ関連 ===
 
   # "ruby,array" / ["ruby","array"] を配列に整形
   def parse_tags(val)
@@ -94,5 +121,21 @@ class PreCodesController < ApplicationController
     else
       name.to_s.unicode_normalize(:nfkc).strip.downcase.gsub(/\s+/, " ")
     end
+  end
+
+  # タグ集合置換
+  def replace_tags(pre_code, raw_names)
+    return if raw_names.nil? # 未指定なら現集合を維持
+
+    names = raw_names
+              .to_s
+              .tr("　", " ")               # 全角スペース→半角
+              .split(/[,\s]+/)             # カンマ or 空白区切り
+              .map(&:strip)
+              .reject(&:blank?)
+              .uniq
+
+    new_tags = names.map { |n| Tag.find_or_create_by!(name: n) }
+    pre_code.tags = new_tags
   end
 end

--- a/app/helpers/pre_codes_helper.rb
+++ b/app/helpers/pre_codes_helper.rb
@@ -1,2 +1,9 @@
+# app/helpers/pre_codes_helper.rb
 module PreCodesHelper
+  ALLOWED_TAGS = %w[b i em strong code pre br p ul ol li a].freeze
+  ALLOWED_ATTRS = %w[href].freeze
+
+  def sanitized_html(html)
+    sanitize(html, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRS)
+  end
 end

--- a/app/javascript/controllers/precode_mode_controller.js
+++ b/app/javascript/controllers/precode_mode_controller.js
@@ -1,0 +1,51 @@
+// app/javascript/controllers/precode_mode_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+// モード切替：通常 / 問題
+export default class extends Controller {
+  static targets = [
+    "toggle", "titleLabel", "descLabel",
+    "quizBlock",          // 複数（ヒントブロック／解答ブロック）
+    "answerField",        // textarea[name="pre_code[answer]"]
+    "answerCodeField"     // textarea[name="pre_code[answer_code]"]
+  ]
+  static values  = { mode: String } // "normal" | "quiz"
+
+  connect() {
+    this.modeValue ||= "normal"
+    this.apply()
+  }
+
+  switch() {
+    this.modeValue = (this.modeValue === "normal") ? "quiz" : "normal"
+    this.apply()
+  }
+
+  apply() {
+    const quiz = this.modeValue === "quiz"
+
+    // ラベル切替
+    if (this.hasTitleLabelTarget) this.titleLabelTarget.textContent = quiz ? "問題タイトル" : "登録名"
+    if (this.hasDescLabelTarget)  this.descLabelTarget.textContent  = quiz ? "問題文"       : "コードの説明"
+
+    // ヒント／解答ブロックの表示非表示（複数ターゲット）
+    if (this.hasQuizBlockTarget) {
+      this.quizBlockTargets.forEach(el => el.classList.toggle("hidden", !quiz))
+    }
+
+    // answer を問題モード時のみ required・有効にする
+    if (this.hasAnswerFieldTarget) {
+      this.answerFieldTarget.toggleAttribute("required", quiz)
+      this.answerFieldTarget.disabled = !quiz
+    }
+    // answer_code も問題モード時のみ有効に（必須にはしない）
+    if (this.hasAnswerCodeFieldTarget) {
+      this.answerCodeFieldTarget.disabled = !quiz
+    }
+
+    // トグルボタン表示
+    if (this.hasToggleTarget) {
+      this.toggleTarget.textContent = quiz ? "通常モードに戻す" : "問題モードにする"
+    }
+  }
+}

--- a/app/javascript/controllers/reveal_controller.js
+++ b/app/javascript/controllers/reveal_controller.js
@@ -1,0 +1,23 @@
+// app/javascript/controllers/reveal_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+// 指定要素を show/hide。初期は hidden（CSSで隠す）想定。
+export default class extends Controller {
+  static targets = ["button", "content"]
+  static values  = { shown: Boolean }
+
+  connect() {
+    this.shownValue ||= false
+    this.apply()
+  }
+
+  toggle() {
+    this.shownValue = !this.shownValue
+    this.apply()
+  }
+
+  apply() {
+    this.contentTargets.forEach(el => el.classList.toggle("hidden", !this.shownValue))
+    if (this.hasButtonTarget) this.buttonTarget.textContent = this.shownValue ? "非表示にする" : "表示する"
+  }
+}

--- a/app/models/pre_code.rb
+++ b/app/models/pre_code.rb
@@ -14,6 +14,9 @@ class PreCode < ApplicationRecord
 
   validates :description, length: { maximum: 2000 }, allow_blank: true
   validates :body, presence: true
+  validates :hint,   length: { maximum: 1000 }, allow_blank: true
+  validates :answer, presence: true, length: { maximum: 2000 }
+  validates :answer_code, length: { maximum: 2000 }
 
   # === 一覧・並び替え向けスコープ ===
   scope :except_user, ->(uid) { uid.present? ? where.not(user_id: uid) : all }

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -79,7 +79,12 @@
 
         <div class="flex justify-between">
           <div class="flex-1 pr-4">
-            <div class="font-semibold"><%= pc.title %></div>
+            <div class="font-semibold flex items-center gap-2">
+              <%= pc.title %>
+              <% if pc.answer.present? %>
+                <span class="text-[10px] px-1.5 py-0.5 rounded bg-amber-200 text-amber-800">QUIZ</span>
+              <% end %>
+            </div>
 
             <%# タイトルの下に「静的」タグピルを表示（リンクなし・ネスト事故回避） %>
             <div class="mt-2">

--- a/app/views/code_libraries/show.html.erb
+++ b/app/views/code_libraries/show.html.erb
@@ -43,6 +43,22 @@
     </div>
   </section>
 
+  <%# ===== ヒント ===== %>
+  <% if @pre_code.hint.present? %>
+    <section data-controller="reveal" class="space-y-2">
+      <div class="flex items-baseline justify-between">
+        <h2 class="text-sm font-semibold tracking-wider text-slate-500">ヒント</h2>
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-reveal-target="button" data-action="reveal#toggle">表示する</button>
+      </div>
+
+      <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+           data-reveal-target="content">
+        <%= raw @pre_code.hint %>
+      </div>
+    </section>
+  <% end %>
+
   <%# ===== 登録コード ===== %>
   <section>
     <div class="flex items-baseline justify-between">
@@ -59,6 +75,35 @@
       <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
     </div>
   </section>
+
+  <%# ===== 解答 ===== %>
+  <% if @pre_code.answer.present? || @pre_code.answer_code.present? %>
+    <section data-controller="reveal" class="space-y-2">
+      <div class="flex items-baseline justify-between">
+        <h2 class="text-sm font-semibold tracking-wider text-slate-500">解答</h2>
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-reveal-target="button" data-action="reveal#toggle">表示する</button>
+      </div>
+
+      <% if @pre_code.answer.present? %>
+        <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+             data-reveal-target="content">
+          <%= raw @pre_code.answer %>
+        </div>
+      <% end %>
+
+      <% if @pre_code.answer_code.present? %>
+        <div class="hidden" data-reveal-target="content">
+          <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+          <div data-controller="code-view" data-code-view-theme-value="light"
+               class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
+            <textarea data-code-view-target="field" class="hidden"><%= @pre_code.answer_code %></textarea>
+            <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
+          </div>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
 
   <%# ===== 最下部：中央に「このデータを利用する」 ===== %>
   <div class="-mt-2 text-center">

--- a/app/views/code_libraries/show.html.erb
+++ b/app/views/code_libraries/show.html.erb
@@ -53,8 +53,10 @@
       </div>
 
       <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
-           data-reveal-target="content">
-        <%= raw @pre_code.hint %>
+          data-reveal-target="content">
+        <%= sanitize(@pre_code.hint,
+                    tags: %w[b i em strong code pre br p ul ol li a],
+                    attributes: %w[href]) %>
       </div>
     </section>
   <% end %>
@@ -87,8 +89,10 @@
 
       <% if @pre_code.answer.present? %>
         <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
-             data-reveal-target="content">
-          <%= raw @pre_code.answer %>
+            data-reveal-target="content">
+          <%= sanitize(@pre_code.answer,
+                      tags: %w[b i em strong code pre br p ul ol li a],
+                      attributes: %w[href]) %>
         </div>
       <% end %>
 
@@ -96,7 +100,7 @@
         <div class="hidden" data-reveal-target="content">
           <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
           <div data-controller="code-view" data-code-view-theme-value="light"
-               class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
+              class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
             <textarea data-code-view-target="field" class="hidden"><%= @pre_code.answer_code %></textarea>
             <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
           </div>

--- a/app/views/pre_codes/_form.html.erb
+++ b/app/views/pre_codes/_form.html.erb
@@ -1,74 +1,93 @@
-<%# エラー表示（共通パーシャル活用） %>
+<!-- app/views/pre_codes/_form.html.erb -->
 <%= render "shared/errors", object: pre_code %>
 
-<%= form_with model: pre_code, class: "space-y-4" do |f| %>
+<%= form_with model: pre_code, class: "space-y-6" do |f| %>
+  <div data-controller="precode-mode"
+       data-precode-mode-mode-value="normal"
+       class="space-y-6">
 
-  <div>
-    <%# 登録名 %>
-    <%= f.label :title, "登録名", class: "block text-sm mb-1" %>
-    <%= f.text_field :title,
-          placeholder: "選択時に表示する名前を入力してください",
-          class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-  </div>
+    <div class="flex items-center justify-end">
+      <button type="button"
+              class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+              data-precode-mode-target="toggle"
+              data-action="precode-mode#switch">
+        問題モードにする
+      </button>
+    </div>
 
-  <div class="mt-4">
-    <label class="block text-sm mb-1">タグ（最大10個）</label>
-    <input id="tag-input" name="tag_names" value="<%= @pre_code.tags.map(&:name).join(',') %>"
-          class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2"
-          placeholder="例: ruby, array, sql" data-controller="tag-token" data-action="input->tag-token#suggest">
-    <div id="tag-suggest" class="mt-1 text-sm text-slate-500"></div>
-  </div>
-
-  <div>
-    <%# コードの説明 %>
-    <%= f.label :description, "コードの説明", class: "block text-sm mb-1" %>
-
-    <div data-controller="autosize"
-        data-autosize-min-rows-value="3"
-        data-autosize-max-length-value="2000">
-      <%= f.text_area :description,
-            rows: 3,
-            maxlength: 2000,
-            data: { autosize_target: "field" },
-            placeholder: "コード内容の説明を簡単に書いてください",
+    <!-- タイトル -->
+    <div class="space-y-2">
+      <label class="block text-sm font-semibold text-slate-500"
+             data-precode-mode-target="titleLabel">登録名</label>
+      <%= f.text_field :title,
+            placeholder: "選択肢に表示する名前を入力してください",
             class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+    </div>
 
-      <div class="mt-1 text-xs text-slate-500">
-        残り <span data-autosize-target="counter">2000</span> 文字
+    <!-- タグ -->
+    <div class="space-y-2">
+      <label class="block text-sm font-semibold text-slate-500">タグ（最大10個）</label>
+      <input id="tag-input" name="tag_names" value="<%= @pre_code.tags.map(&:name).join(',') %>"
+             class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2"
+             placeholder="例: ruby, array, sql"
+             data-controller="tag-token"
+             data-action="input->tag-token#suggest">
+      <div id="tag-suggest" class="text-sm text-slate-500"></div>
+    </div>
+
+    <!-- 説明 -->
+    <div class="space-y-2">
+      <label class="block text-sm font-semibold text-slate-500"
+             data-precode-mode-target="descLabel">コードの説明</label>
+      <%= f.text_area :description, rows: 3,
+            placeholder: "コード内容の説明を簡単に書いてください",
+            class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+
+    <!-- ▼ ヒント（問題モード時のみ表示） -->
+    <div data-precode-mode-target="quizBlock" class="space-y-2 hidden">
+      <label class="block text-sm font-semibold text-slate-500">ヒント（任意）</label>
+      <%= f.text_area :hint, rows: 3,
+            placeholder: "ヒント本文（1000文字まで）",
+            class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+
+    <!-- ▼ 登録コード（常に表示） -->
+    <div class="space-y-2">
+      <label class="block text-sm font-semibold text-slate-500">登録コード</label>
+      <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+      <div data-controller="precode-body" data-precode-body-theme-value="light"
+           class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
+        <%= f.text_area :body, data: { "precode-body-target": "field" }, class: "hidden" %>
+        <div data-precode-body-target="mount" class="w-full min-h-[300px]"></div>
+      </div>
+    </div>
+
+    <!-- ▼ 解答（問題モード時のみ表示） -->
+    <div data-precode-mode-target="quizBlock" class="space-y-2 hidden">
+      <label class="block text-sm font-semibold text-slate-500">解答（必須）</label>
+      <%= f.text_area :answer, rows: 4,
+            placeholder: "解答本文（2000文字まで）",
+            class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2",
+            data: { "precode-mode-target": "answerField" } %>
+
+      <div class="space-y-2">
+        <label class="block text-sm font-semibold text-slate-500">解答用コード（任意）</label>
+        <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+        <div data-controller="precode-body" data-precode-body-theme-value="light"
+             class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
+          <%= f.text_area :answer_code,
+                data: { "precode-body-target": "field",
+                        "precode-mode-target": "answerCodeField" },
+                class: "hidden" %>
+          <div data-precode-body-target="mount" class="w-full min-h-[200px]"></div>
+        </div>
       </div>
     </div>
   </div>
 
-  <%# === 登録コード（CodeMirror） === %>
-  <div>
-    <%# タイトル、テーマ切り替えボタン %>
-    <div data-controller="precode-body" data-precode-body-theme-value="light">
-      <div class="flex items-center justify-between">
-        <label class="block text-sm">登録コード</label>
-        <button type="button"
-                data-action="precode-body#toggleTheme"
-                class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm">
-          テーマ切替
-        </button>
-      </div>
-
-      <%# textarea は非表示でフォーム送信用の実体 %>
-      <%= f.text_area :body,
-            data:  { precode_body_target: "field" },
-            class: "hidden" %>
-
-      <%# CodeMirror をマウント。角丸なし & スクロールはここに出す %>
-      <style>
-        .cm-editor, .cm-scroller { background: transparent !important; }
-      </style>
-      <div data-precode-body-target="mount"
-          class="w-full min-h-[300px] ring-1 ring-slate-300 rounded-none overflow-hidden"></div>
-    </div>
-  </div>
-
-  <%# === 送信ボタン（中央寄せ＆幅広＋赤） === %>
-  <div class="mt-6 flex justify-center">
+  <div class="flex justify-center">
     <%= f.submit (pre_code.new_record? ? "登録" : "更新"),
-          class: "inline-flex justify-center w-64 md:w-80 lg:w-96 bg-[#CC0000] text-white px-4 py-2 rounded hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+          class: "inline-flex justify-center w-64 bg-[#CC0000] text-white px-4 py-2 rounded hover:bg-[#BB0000] active:bg-[#AA0000]" %>
   </div>
 <% end %>

--- a/app/views/pre_codes/index.html.erb
+++ b/app/views/pre_codes/index.html.erb
@@ -62,7 +62,12 @@
             <!-- 左：タイトル／説明 -->
             <div class="flex-1 pr-4">
               <!-- タイトル -->
-              <div class="font-semibold"><%= pc.title %></div>
+              <div class="font-semibold flex items-center gap-2">
+                <%= pc.title %>
+                <% if pc.answer.present? %>
+                  <span class="text-[10px] px-1.5 py-0.5 rounded bg-amber-200 text-amber-800">QUIZ</span>
+                <% end %>
+              </div>
 
               <!-- タグピル（タイトルの下） -->
               <div class="mt-2">

--- a/app/views/pre_codes/show.html.erb
+++ b/app/views/pre_codes/show.html.erb
@@ -31,6 +31,22 @@
     </div>
   </section>
 
+  <!-- ヒント -->
+  <% if @pre_code.hint.present? %>
+    <section data-controller="reveal" class="space-y-2">
+      <div class="flex items-baseline justify-between">
+        <h2 class="text-sm font-semibold tracking-wider text-slate-500">ヒント</h2>
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-reveal-target="button" data-action="reveal#toggle">表示する</button>
+      </div>
+
+      <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+           data-reveal-target="content">
+        <%= raw @pre_code.hint %>
+      </div>
+    </section>
+  <% end %>
+
   <!-- 登録コード + 最終更新 -->
   <section>
     <div class="flex items-baseline justify-between">
@@ -53,6 +69,35 @@
       <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
     </div>
   </section>
+
+  <!-- 解答 -->
+  <% if @pre_code.answer.present? || @pre_code.answer_code.present? %>
+    <section data-controller="reveal" class="space-y-2">
+      <div class="flex items-baseline justify-between">
+        <h2 class="text-sm font-semibold tracking-wider text-slate-500">解答</h2>
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-reveal-target="button" data-action="reveal#toggle">表示する</button>
+      </div>
+
+      <% if @pre_code.answer.present? %>
+        <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+             data-reveal-target="content">
+          <%= raw @pre_code.answer %>
+        </div>
+      <% end %>
+
+      <% if @pre_code.answer_code.present? %>
+        <div class="hidden" data-reveal-target="content">
+          <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+          <div data-controller="code-view" data-code-view-theme-value="light"
+               class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
+            <textarea data-code-view-target="field" class="hidden"><%= @pre_code.answer_code %></textarea>
+            <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
+          </div>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
 
   <!-- === 利用ボタン（中央固定・カウントなし） === -->
   <section class="-mt-2">

--- a/app/views/pre_codes/show.html.erb
+++ b/app/views/pre_codes/show.html.erb
@@ -41,8 +41,10 @@
       </div>
 
       <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
-           data-reveal-target="content">
-        <%= raw @pre_code.hint %>
+          data-reveal-target="content">
+        <%= sanitize(@pre_code.hint,
+                    tags: %w[b i em strong code pre br p ul ol li a],
+                    attributes: %w[href]) %>
       </div>
     </section>
   <% end %>
@@ -81,8 +83,10 @@
 
       <% if @pre_code.answer.present? %>
         <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
-             data-reveal-target="content">
-          <%= raw @pre_code.answer %>
+            data-reveal-target="content">
+          <%= sanitize(@pre_code.answer,
+                      tags: %w[b i em strong code pre br p ul ol li a],
+                      attributes: %w[href]) %>
         </div>
       <% end %>
 
@@ -90,7 +94,7 @@
         <div class="hidden" data-reveal-target="content">
           <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
           <div data-controller="code-view" data-code-view-theme-value="light"
-               class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
+              class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
             <textarea data-code-view-target="field" class="hidden"><%= @pre_code.answer_code %></textarea>
             <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
           </div>

--- a/db/migrate/20250925184317_add_hint_and_answer_to_pre_codes.rb
+++ b/db/migrate/20250925184317_add_hint_and_answer_to_pre_codes.rb
@@ -1,0 +1,6 @@
+class AddHintAndAnswerToPreCodes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :pre_codes, :hint, :text
+    add_column :pre_codes, :answer, :text
+  end
+end

--- a/db/migrate/20250925232703_add_answer_code_to_pre_codes_and_drop_hint_code.rb
+++ b/db/migrate/20250925232703_add_answer_code_to_pre_codes_and_drop_hint_code.rb
@@ -1,0 +1,13 @@
+class AddAnswerCodeToPreCodesAndDropHintCode < ActiveRecord::Migration[8.0]
+  def change
+    # answer_code を追加（なければ）
+    unless column_exists?(:pre_codes, :answer_code)
+      add_column :pre_codes, :answer_code, :text
+    end
+
+    # hint_code を削除（あれば）
+    if column_exists?(:pre_codes, :hint_code)
+      remove_column :pre_codes, :hint_code, :text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_25_034231) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_25_232703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -114,6 +114,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_034231) do
     t.integer "use_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "hint"
+    t.text "answer"
+    t.text "answer_code"
     t.index ["title"], name: "index_pre_codes_on_title"
     t.index ["user_id", "created_at"], name: "index_pre_codes_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_pre_codes_on_user_id"

--- a/spec/factories/pre_codes.rb
+++ b/spec/factories/pre_codes.rb
@@ -2,17 +2,21 @@
 FactoryBot.define do
   factory :pre_code do
     association :user
-    sequence(:title)       { |n| "Sample Title #{n}" }   # 衝突しにくいように連番化
-    description            { "sample description" }
-    body                   { "puts 'hello world'" }
-    like_count             { 0 }
-    use_count              { 0 }
+    sequence(:title) { |n| "Sample Title #{n}" }
+    description      { "sample description" }
+    body             { "puts 'hello world'" }
+    like_count       { 0 }
+    use_count        { 0 }
+    hint        { "これはヒントです" }    # 任意
+    answer      { "これは解答です" }      # 必須
+    answer_code  { "puts 'answer code example'" }
   end
 
-  # One-pager のサンプル値に合わせた派生ファクトリ
   factory :pre_code_sample, parent: :pre_code do
     title       { "サンプル#{SecureRandom.hex(2)}" }
     description { "説明テキスト" }
     body        { "puts 'hello'" }
+    hint        { "サンプルのヒント" }
+    answer      { "サンプルの解答" }
   end
 end

--- a/spec/models/pre_code_quiz_spec.rb
+++ b/spec/models/pre_code_quiz_spec.rb
@@ -1,0 +1,27 @@
+# spec/models/pre_code_quiz_spec.rb
+require "rails_helper"
+
+RSpec.describe PreCode, type: :model do
+  it "answer が必須" do
+    pc = build(:pre_code, answer: nil)
+    expect(pc).to be_invalid
+    expect(pc.errors[:answer]).to be_present
+  end
+
+  it "hint は 1000 文字以内" do
+    pc = build(:pre_code, hint: "あ" * 1001, answer: "OK")
+    expect(pc).to be_invalid
+    expect(pc.errors[:hint]).to be_present
+  end
+
+  it "answer は 2000 文字以内" do
+    pc = build(:pre_code, answer: "あ" * 2001)
+    expect(pc).to be_invalid
+    expect(pc.errors[:answer]).to be_present
+  end
+
+  it "有効な値なら保存できる" do
+    pc = build(:pre_code, hint: "ヒント", answer: "解答")
+    expect(pc).to be_valid
+  end
+end

--- a/spec/requests/pre_codes_quiz_spec.rb
+++ b/spec/requests/pre_codes_quiz_spec.rb
@@ -1,0 +1,44 @@
+# spec/requests/pre_codes_quiz_spec.rb
+require "rails_helper"
+
+RSpec.describe "PreCodes (Quiz)", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  it "解答が空だと 422 で失敗する" do
+    params = attributes_for(:pre_code).merge(answer: nil, hint: "h")
+    post pre_codes_path, params: { pre_code: params }
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  it "作成時に hint/answer が保存される" do
+    params = attributes_for(:pre_code).merge(hint: "ヒント", answer: "解答")
+    post pre_codes_path, params: { pre_code: params }
+    expect(response).to have_http_status(:found)
+    pc = PreCode.order(:id).last
+    expect(pc.hint).to include("ヒント")
+    expect(pc.answer).to include("解答")
+  end
+
+  it "保存前にサニタイズされる" do
+    params = attributes_for(:pre_code).merge(
+      hint:   %(<script>alert(1)</script><b>ok</b>),
+      answer: %(<img src=x onerror=alert(1)>safe)
+    )
+    post pre_codes_path, params: { pre_code: params }
+    pc = PreCode.order(:id).last
+    expect(pc.hint).to include("<b>ok</b>")
+    expect(pc.hint).not_to include("<script>")
+    expect(pc.answer).to include("safe")
+    expect(pc.answer).not_to include("onerror")
+  end
+
+  it "更新でも同様に動作する" do
+    pc = create(:pre_code, user:, answer: "x")
+    patch pre_code_path(pc), params: { pre_code: { answer: "y", hint: "h2" } }
+    expect(response).to have_http_status(:found)
+    expect(pc.reload.answer).to eq("y")
+    expect(pc.reload.hint).to eq("h2")
+  end
+end


### PR DESCRIPTION
### 概要
PreCode に「問題モード（QUIZ）」を追加し、ヒント／解答の入力・表示とUXを整備した。

**作業内容**

- DB に hint:text, answer:text, answer_code:text を追加し、Model に検証（answer 必須・文字数上限）を実装、保存前サニタイズを適用
- フォームに問題モード切替（Stimulus）を実装し、ヒント→登録コード→解答の順で表示、通常時は解答ブロックを非表示
- ブラウザ検証で送信が止まらないよう、問題モード時のみ answer を required/enable、通常時は disable（answer_code も同様に enable/disable）
- 詳細画面にヒント／解答の表示トグルを追加（初期非表示・ボタンで展開）、一覧に QUIZ バッジを表示
- リクエスト／モデルのRSpecを追加し、作成・更新・サニタイズ・検証エラーの動作を担保