### PR TITLE
本番不具合の一括修正：PreCode通常/問題モード判定・管理編集/詳細整備・タグ検索/いいねTurboStream・入力UI改善とQui…

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -45,3 +45,12 @@
          active:bg-black
          focus:outline-none focus:ring-2 focus:ring-slate-500;
 }
+
+/* Quill ツールバーを画面上部に固定 */
+.ql-toolbar {
+  position: sticky;
+  top: 0;               /* 画面の一番上に固定 */
+  z-index: 50;          /* ヘッダーより上に出すなら調整 */
+  background: #fff;     /* 背景色を固定しないと透ける */
+  border-bottom: 1px solid #e5e7eb; /* 下線を追加して区切り感を出す */
+}

--- a/app/controllers/admin/pre_codes_controller.rb
+++ b/app/controllers/admin/pre_codes_controller.rb
@@ -5,7 +5,7 @@ class Admin::PreCodesController < Admin::BaseController
 
   # GET /admin/pre_codes
   def index
-    rel = PreCode.includes(:user) # （タグがあれば :tags も）
+    rel  = PreCode.includes(:user) # タグも読むなら :tags を preload へ
     norm = ->(s) { s.to_s.unicode_normalize(:nfkc).downcase }
 
     if params[:title].present?
@@ -21,10 +21,11 @@ class Admin::PreCodesController < Admin::BaseController
       rel = rel.joins(:user).where("LOWER(users.name) LIKE ? OR LOWER(users.email) LIKE ?", q, q)
     end
 
-    # タグ AND（Tag/Tagging がある場合）
+    # タグ AND（タグ機能がある場合）
     if PreCode.reflect_on_association(:tags) && (tag_ids = Array(params[:tag_ids]).reject(&:blank?)).present?
       rel = rel.joins(:tags).where(tags: { id: tag_ids })
-               .group("pre_codes.id").having("COUNT(DISTINCT tags.id) = ?", tag_ids.size)
+               .group("pre_codes.id")
+               .having("COUNT(DISTINCT tags.id) = ?", tag_ids.size)
     end
 
     rel =
@@ -42,7 +43,14 @@ class Admin::PreCodesController < Admin::BaseController
   def edit; end
 
   def update
-    if @pre_code.update(pre_code_params)
+    # 一般側と同様：quiz_mode の有無で answer を必須にするため、更新前にセット
+    @pre_code.quiz_mode = params.dig(:pre_code, :quiz_mode)
+
+    attrs = pre_code_params_with_sanitized_text
+
+    if @pre_code.update(attrs)
+      # タグ（文字列: "ruby, array"）を置換
+      replace_tags(@pre_code, params[:tag_names])
       redirect_to [ :admin, @pre_code ], notice: "更新しました"
     else
       render :edit, status: :unprocessable_entity
@@ -60,8 +68,49 @@ class Admin::PreCodesController < Admin::BaseController
     @pre_code = PreCode.find(params[:id])
   end
 
-  # 一般フォームと同じパラメータに合わせる
+  # ===== Strong Params（一般側と合わせる） =====
   def pre_code_params
-    params.require(:pre_code).permit(:title, :description, :body, :hint, :answer, :problem_mode, tag_ids: [])
+    params.require(:pre_code).permit(
+      :title, :description, :body,
+      :hint, :answer, :answer_code,
+      :quiz_mode
+    )
+  end
+
+  # テキスト系は保存前にサニタイズ（一般側と同等）
+  def pre_code_params_with_sanitized_text
+    attrs = pre_code_params
+
+    sanitizer =
+      if respond_to?(:sanitize_content, true)
+        method(:sanitize_content)
+      else
+        ->(html) {
+          ActionController::Base.helpers.sanitize(
+            html,
+            tags: %w[b i em strong code pre br p ul ol li a],
+            attributes: %w[href]
+          )
+        }
+      end
+
+    attrs[:hint]   = sanitizer.call(attrs[:hint])   if attrs.key?(:hint)
+    attrs[:answer] = sanitizer.call(attrs[:answer]) if attrs.key?(:answer)
+    attrs
+  end
+
+  # ===== タグ関連（一般側と同等の「文字列」入力を受ける） =====
+  # "ruby, array" / ["ruby", "array"] を配列化して正規化なしで登録（必要なら Tag.normalize を利用）
+  def replace_tags(pre_code, raw_names)
+    return if raw_names.nil?
+
+    names = raw_names.to_s.tr("　", " ")
+                       .split(/[,\s]+/)
+                       .map(&:strip)
+                       .reject(&:blank?)
+                       .uniq
+
+    new_tags = names.map { |n| Tag.find_or_create_by!(name: n) }
+    pre_code.tags = new_tags
   end
 end

--- a/app/controllers/code_libraries_controller.rb
+++ b/app/controllers/code_libraries_controller.rb
@@ -3,16 +3,41 @@ class CodeLibrariesController < ApplicationController
 
   def index
     base = PreCode.except_user(current_user&.id)
+
+    # --- タグ AND フィルタ（サブクエリで ID のみ絞る） ---
+    if params[:tags].present?
+      tag_keys  = parse_tags(params[:tags])
+      norm_keys = tag_keys.map { |n| normalize_tag(n) }.uniq
+
+      if norm_keys.any?
+        tag_ids = Tag.where(name_norm: norm_keys).pluck(:id)
+
+        base =
+          if tag_ids.any?
+            # 選択されたタグを“すべて”持つ PreCode の id を抽出
+            tagged_ids = PreCode.joins(:tags)
+                                 .where(tags: { id: tag_ids })
+                                 .group("pre_codes.id")
+                                 .having("COUNT(DISTINCT tags.id) = ?", tag_ids.size)
+                                 .select(:id)
+            base.where(id: tagged_ids)
+          else
+            base.none
+          end
+      end
+    end
+
+    # キーワード検索
     @q = base.ransack(params[:q])
     rel = @q.result
 
+    # --- ブックマークのみ表示（ログイン時） ---
     if params[:only_bookmarked].present? && logged_in?
       rel = rel.joins(:bookmarks).where(bookmarks: { user_id: current_user.id })
     end
 
-    # ソートキー（popular / used / newest）。デフォルト popular
+    # 並び順（popular / used / newest）
     sort_key = params[:sort].presence || "popular"
-
     rel =
       case sort_key
       when "used"
@@ -23,7 +48,8 @@ class CodeLibrariesController < ApplicationController
         rel.order(like_count: :desc).order(use_count: :desc).order(created_at: :desc)
       end
 
-    @pre_codes = rel.includes(:user).page(params[:page])
+    # N+1 対策（GROUP を避けるため JOIN ではなく preload）
+    @pre_codes = rel.preload(:user, :tags).page(params[:page])
   end
 
   def show
@@ -36,5 +62,20 @@ class CodeLibrariesController < ApplicationController
 
   def set_pre_code
     @pre_code = PreCode.find(params[:id])
+  end
+
+  # === タグ文字列ユーティリティ ===
+  # "ruby,array" / ["ruby","array"] を配列に整形
+  def parse_tags(val)
+    Array(val).flat_map { |v| v.to_s.split(",") }.map(&:strip).reject(&:blank?)
+  end
+
+  # Tag.normalize があれば使用、なければ簡易正規化
+  def normalize_tag(name)
+    if Tag.respond_to?(:normalize)
+      Tag.normalize(name)
+    else
+      name.to_s.unicode_normalize(:nfkc).strip.downcase.gsub(/\s+/, " ")
+    end
   end
 end

--- a/app/controllers/pre_codes_controller.rb
+++ b/app/controllers/pre_codes_controller.rb
@@ -3,20 +3,16 @@ class PreCodesController < ApplicationController
   before_action :require_login!
   before_action :set_pre_code, only: %i[show edit update destroy]
 
-  # GET /pre_codes
   def index
     base = current_user.pre_codes
 
-    # --- タグ AND フィルタ ---
     if params[:tags].present?
-      tag_keys = parse_tags(params[:tags]) # "ruby,array" or ["ruby","array"]
+      tag_keys = parse_tags(params[:tags])
       norm_keys = tag_keys.map { |n| normalize_tag(n) }.uniq
-
       if norm_keys.any?
         tag_ids = Tag.where(name_norm: norm_keys).pluck(:id)
         base =
           if tag_ids.any?
-            # AND 検索：選んだタグ数と一致するまで group/having
             base.joins(:tags)
                 .where(tags: { id: tag_ids })
                 .group("pre_codes.id")
@@ -31,39 +27,33 @@ class PreCodesController < ApplicationController
     @pre_codes = @q.result.order(id: :desc).page(params[:page])
   end
 
-  # GET /pre_codes/:id
   def show; end
 
-  # GET /pre_codes/new
   def new
     @pre_code = current_user.pre_codes.build
   end
 
-  # POST /pre_codes
   def create
     @pre_code = current_user.pre_codes.build(pre_code_params)
     if @pre_code.save
-      replace_tags(@pre_code, params[:tag_names]) # ★ タグ付与
+      replace_tags(@pre_code, params[:tag_names])
       redirect_to @pre_code, notice: "PreCode を作成しました"
     else
       render :new, status: :unprocessable_entity
     end
   end
 
-  # GET /pre_codes/:id/edit
   def edit; end
 
-  # PATCH/PUT /pre_codes/:id
   def update
     if @pre_code.update(pre_code_params)
-      replace_tags(@pre_code, params[:tag_names]) # ★ タグ更新
+      replace_tags(@pre_code, params[:tag_names])
       redirect_to @pre_code, notice: "PreCode を更新しました"
     else
       render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /pre_codes/:id
   def destroy
     @pre_code.destroy
     redirect_to pre_codes_path, notice: "PreCode を削除しました"
@@ -71,7 +61,6 @@ class PreCodesController < ApplicationController
 
   private
 
-  # 所有者スコープで取得（他人IDは 404）
   def set_pre_code
     @pre_code = current_user.pre_codes.find(params[:id])
   end
@@ -80,10 +69,11 @@ class PreCodesController < ApplicationController
   def pre_code_params
     attrs = params.require(:pre_code).permit(
       :title, :description, :body,
-      :hint, :answer, :answer_code
+      :hint, :answer, :answer_code,
+      :quiz_mode
     )
 
-    # テキストだけサニタイズ（コードはサニタイズしない）
+    # テキストだけサニタイズ
     sanitizer = if respond_to?(:sanitize_content, true)
                   method(:sanitize_content)
     else
@@ -96,25 +86,17 @@ class PreCodesController < ApplicationController
                   }
     end
 
-    # キーがある時だけ代入（nil を上書きしない）
-    if attrs.key?(:hint)
-      attrs[:hint] = sanitizer.call(attrs[:hint])
-    end
-    if attrs.key?(:answer)
-      attrs[:answer] = sanitizer.call(attrs[:answer])
-    end
+    attrs[:hint]   = sanitizer.call(attrs[:hint])   if attrs.key?(:hint)
+    attrs[:answer] = sanitizer.call(attrs[:answer]) if attrs.key?(:answer)
 
     attrs
   end
 
   # === タグ関連 ===
-
-  # "ruby,array" / ["ruby","array"] を配列に整形
   def parse_tags(val)
     Array(val).flat_map { |v| v.to_s.split(",") }.map(&:strip).reject(&:blank?)
   end
 
-  # Tag.normalize があれば使用。無ければ簡易正規化（NFKC→strip→downcase→空白正規化）
   def normalize_tag(name)
     if Tag.respond_to?(:normalize)
       Tag.normalize(name)
@@ -123,17 +105,11 @@ class PreCodesController < ApplicationController
     end
   end
 
-  # タグ集合置換
   def replace_tags(pre_code, raw_names)
-    return if raw_names.nil? # 未指定なら現集合を維持
+    return if raw_names.nil?
 
-    names = raw_names
-              .to_s
-              .tr("　", " ")               # 全角スペース→半角
-              .split(/[,\s]+/)             # カンマ or 空白区切り
-              .map(&:strip)
-              .reject(&:blank?)
-              .uniq
+    names = raw_names.to_s.tr("　", " ")
+              .split(/[,\s]+/).map(&:strip).reject(&:blank?).uniq
 
     new_tags = names.map { |n| Tag.find_or_create_by!(name: n) }
     pre_code.tags = new_tags

--- a/app/javascript/controllers/autosize_controller.js
+++ b/app/javascript/controllers/autosize_controller.js
@@ -1,34 +1,49 @@
-import { Controller } from "@hotwired/stimulus";
+// app/javascript/controllers/autosize_controller.js
+import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["field", "counter"]; // ← 追加：textarea とカウンタ
-  static values = {
-    minRows: Number,
-    maxLength: Number,
-  };
+  static targets = ["field", "counter"]
+  static values  = { minRows: Number, maxLength: Number }
 
   connect() {
-    this.grow();
-    this.updateCounter();
-    this.fieldTarget.addEventListener("input", () => {
-      this.grow();
-      this.updateCounter();
-    });
+    // 同一要素に controller と target を同居させてもOK
+    this._onInput   = () => { this.grow(); this.updateCounter() }
+    this._onRefresh = () => { this.grow(); this.updateCounter() }
+
+    this.fieldTarget.addEventListener("input", this._onInput)
+    // precode-mode 側から送るカスタムイベント
+    this.element.addEventListener("autosize:refresh", this._onRefresh)
+
+    this.grow()
+    this.updateCounter()
+  }
+
+  disconnect() {
+    this.fieldTarget.removeEventListener("input", this._onInput)
+    this.element.removeEventListener("autosize:refresh", this._onRefresh)
   }
 
   grow() {
-    const ta = this.fieldTarget; // ← textarea を明示
-    const baseRows = this.hasMinRowsValue ? this.minRowsValue : (parseInt(ta.getAttribute("rows")) || 2);
-    ta.rows = baseRows;
+    const ta = this.fieldTarget
+    // 非表示（display:none）の時は正しく測れないのでスキップ
+    if (!ta || ta.offsetParent === null) return
 
-    const lineHeight = parseInt(getComputedStyle(ta).lineHeight || "20", 10);
-    const newRows = Math.ceil((ta.scrollHeight - ta.clientTop - ta.clientTop) / lineHeight);
-    ta.rows = Math.max(baseRows, newRows);
+    // rows の初期値（または minRows）を基準にして高さを決める
+    const baseRows = this.hasMinRowsValue
+      ? this.minRowsValue
+      : parseInt(ta.getAttribute("rows") || "2", 10)
+
+    // CSSの高さを直接調整（スクロールバーを出さない）
+    ta.style.overflowY = "hidden"
+    ta.style.height = "auto"
+    // 1行相当の高さに rows を合わせた上で scrollHeight を採用
+    ta.rows = baseRows
+    ta.style.height = `${ta.scrollHeight}px`
   }
 
   updateCounter() {
-    if (!this.hasMaxLengthValue || this.counterTargets.length === 0) return;
-    const remain = Math.max(0, this.maxLengthValue - this.fieldTarget.value.length);
-    this.counterTargets.forEach(el => (el.textContent = remain));
+    if (!this.hasMaxLengthValue || this.counterTargets.length === 0) return
+    const remain = Math.max(0, this.maxLengthValue - this.fieldTarget.value.length)
+    this.counterTargets.forEach(el => { el.textContent = remain })
   }
 }

--- a/app/javascript/controllers/precode_mode_controller.js
+++ b/app/javascript/controllers/precode_mode_controller.js
@@ -5,9 +5,9 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [
     "toggle", "titleLabel", "descLabel",
-    "quizBlock",          // 複数（ヒントブロック／解答ブロック）
-    "answerField",        // textarea[name="pre_code[answer]"]
-    "answerCodeField"     // textarea[name="pre_code[answer_code]"]
+    "quizBlock",
+    "answerField", "answerCodeField",
+    "modeField" // ← hidden の pre_code[quiz_mode]
   ]
   static values  = { mode: String } // "normal" | "quiz"
 
@@ -28,21 +28,30 @@ export default class extends Controller {
     if (this.hasTitleLabelTarget) this.titleLabelTarget.textContent = quiz ? "問題タイトル" : "登録名"
     if (this.hasDescLabelTarget)  this.descLabelTarget.textContent  = quiz ? "問題文"       : "コードの説明"
 
-    // ヒント／解答ブロックの表示非表示（複数ターゲット）
+    // ヒント／解答ブロックの表示非表示
     if (this.hasQuizBlockTarget) {
       this.quizBlockTargets.forEach(el => el.classList.toggle("hidden", !quiz))
     }
 
-    // answer を問題モード時のみ required・有効にする
+    // 必須/有効
     if (this.hasAnswerFieldTarget) {
       this.answerFieldTarget.toggleAttribute("required", quiz)
       this.answerFieldTarget.disabled = !quiz
     }
-    // answer_code も問題モード時のみ有効に（必須にはしない）
     if (this.hasAnswerCodeFieldTarget) {
       this.answerCodeFieldTarget.disabled = !quiz
     }
 
+    // hidden へ現在モードを反映（"true"/"false"）
+    if (this.hasModeFieldTarget) {
+      this.modeFieldTarget.value = quiz ? "true" : "false"
+    }
+
+    // 表示切替後に autosize に再計算を依頼
+    this.element
+      .querySelectorAll('[data-controller~="autosize"]')
+      .forEach(el => el.dispatchEvent(new Event("autosize:refresh")))
+    
     // トグルボタン表示
     if (this.hasToggleTarget) {
       this.toggleTarget.textContent = quiz ? "通常モードに戻す" : "問題モードにする"

--- a/app/models/pre_code.rb
+++ b/app/models/pre_code.rb
@@ -1,5 +1,8 @@
 # app/models/pre_code.rb
 class PreCode < ApplicationRecord
+  # --- 仮想属性（保存しない） ---
+  attr_accessor :quiz_mode
+
   belongs_to :user
   has_many :likes,      dependent: :destroy
   has_many :used_codes, dependent: :destroy
@@ -14,9 +17,12 @@ class PreCode < ApplicationRecord
 
   validates :description, length: { maximum: 2000 }, allow_blank: true
   validates :body, presence: true
-  validates :hint,   length: { maximum: 1000 }, allow_blank: true
-  validates :answer, presence: true, length: { maximum: 2000 }
-  validates :answer_code, length: { maximum: 2000 }
+  validates :hint,        length: { maximum: 1000 }, allow_blank: true
+  validates :answer,      length: { maximum: 2000 }, allow_blank: true
+  validates :answer_code, length: { maximum: 2000 }, allow_blank: true
+
+  # Quiz モードのときだけ answer を必須にする
+  validates :answer, presence: true, if: :quiz_mode?
 
   # === 一覧・並び替え向けスコープ ===
   scope :except_user, ->(uid) { uid.present? ? where.not(user_id: uid) : all }
@@ -37,5 +43,10 @@ class PreCode < ApplicationRecord
 
   def self.ransackable_associations(_auth = nil)
     %w[user]
+  end
+
+  # boolean キャストして判定（"true"/"1"/true を true に）
+  def quiz_mode?
+    ActiveModel::Type::Boolean.new.cast(@quiz_mode)
   end
 end

--- a/app/views/admin/pre_codes/edit.html.erb
+++ b/app/views/admin/pre_codes/edit.html.erb
@@ -1,3 +1,3 @@
 <% content_for :title, "PreCode編集" %>
 <h1 class="text-xl font-semibold mb-4">PreCode編集</h1>
-<%= render "pre_codes/form", pre_code: @pre_code %>
+<%= render "pre_codes/form", pre_code: @pre_code, namespace: :admin %>

--- a/app/views/admin/pre_codes/show.html.erb
+++ b/app/views/admin/pre_codes/show.html.erb
@@ -10,6 +10,18 @@
     </div>
   </section>
 
+  <!-- タグ -->
+  <% if PreCode.reflect_on_association(:tags) %>
+    <section>
+      <h2 class="text-sm font-semibold tracking-wider text-slate-500">タグ</h2>
+      <div class="mt-1 px-1 flex flex-wrap gap-1">
+        <% @pre_code.tags.each do |t| %>
+          <span class="rounded bg-slate-100 px-2 py-0.5 text-[11px] text-slate-700"><%= t.name %></span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
   <!-- コードの説明 -->
   <section>
     <h2 class="text-sm font-semibold tracking-wider text-slate-500">コードの説明</h2>
@@ -20,6 +32,18 @@
     </div>
   </section>
 
+  <!-- ヒント（問題モード時） -->
+  <% if @pre_code.hint.present? %>
+    <section>
+      <h2 class="text-sm font-semibold tracking-wider text-slate-500">ヒント</h2>
+      <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3">
+        <%= sanitize(@pre_code.hint,
+                     tags: %w[b i em strong code pre br p ul ol li a],
+                     attributes: %w[href]) %>
+      </div>
+    </section>
+  <% end %>
+
   <!-- 登録コード + 最終更新 -->
   <section>
     <div class="flex items-baseline justify-between">
@@ -29,28 +53,46 @@
       </p>
     </div>
 
-    <!-- CodeMirror（閲覧専用） -->
-    <style>
-      .cm-editor, .cm-scroller { background: transparent !important; }
-    </style>
-    <div
-      data-controller="code-view"
-      data-code-view-theme-value="light"
-      class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white overflow-hidden"
-    >
+    <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+    <div data-controller="code-view" data-code-view-theme-value="light"
+         class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white overflow-hidden">
       <textarea data-code-view-target="field" class="hidden"><%= @pre_code.body %></textarea>
       <div data-code-view-target="mount" class="w-full min-h-[200px]"></div>
     </div>
   </section>
 
+  <!-- 解答（問題モード時） -->
+  <% if @pre_code.answer.present? || @pre_code.answer_code.present? %>
+    <section class="space-y-2">
+      <h2 class="text-sm font-semibold tracking-wider text-slate-500">解答</h2>
+
+      <% if @pre_code.answer.present? %>
+        <div class="rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3">
+          <%= sanitize(@pre_code.answer,
+                       tags: %w[b i em strong code pre br p ul ol li a],
+                       attributes: %w[href]) %>
+        </div>
+      <% end %>
+
+      <% if @pre_code.answer_code.present? %>
+        <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+        <div data-controller="code-view" data-code-view-theme-value="light"
+             class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
+          <textarea data-code-view-target="field" class="hidden"><%= @pre_code.answer_code %></textarea>
+          <div data-code-view-target="mount" class="w-full min-h-[160px]"></div>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
+
   <!-- 操作（右下寄せ） -->
   <div class="flex justify-end gap-3 pt-2">
     <%= link_to "編集",
-          edit_pre_code_path(@pre_code),
+          [:edit, :admin, @pre_code],
           class: "px-5 py-2 rounded-md bg-[#00AA00] text-white hover:bg-[#009900] active:bg-[#008800]" %>
 
     <%= link_to "削除",
-          @pre_code,
+          [:admin, @pre_code],
           data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
           class: "px-5 py-2 rounded-md bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
   </div>

--- a/app/views/code_libraries/_actions.html.erb
+++ b/app/views/code_libraries/_actions.html.erb
@@ -1,5 +1,10 @@
 <!-- app/views/code_libraries/_actions.html.erb -->
-<%# locals: pre_code:, current_like: %>
+<%# locals: pre_code:, current_like:, current_bookmark: %>
+
+<%# === local が渡ってこないケースでも nil を入れて落ちないように === %>
+<% current_like     = local_assigns.fetch(:current_like, nil) %>
+<% current_bookmark = local_assigns.fetch(:current_bookmark, nil) %>
+
 <div id="<%= dom_id(pre_code, :actions) %>" class="flex gap-2">
   <% if logged_in? %>
     <%# === いいね === %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,8 +1,9 @@
 <!-- app/views/likes/create.turbo_stream.erb -->
 <%= turbo_stream.replace dom_id(@pre_code, :actions) do %>
   <%= render "code_libraries/actions",
-        pre_code: @pre_code,
-        current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
+      pre_code: @pre_code,
+      current_like:      (logged_in? ? @pre_code.likes.find_by(user_id: current_user.id)       : nil),
+      current_bookmark:  (logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id)   : nil) %>
 <% end %>
 
 <%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,8 +1,9 @@
 <!-- app/views/likes/destroy.turbo_stream.erb -->
 <%= turbo_stream.replace dom_id(@pre_code, :actions) do %>
   <%= render "code_libraries/actions",
-        pre_code: @pre_code,
-        current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
+      pre_code: @pre_code,
+      current_like:      (logged_in? ? @pre_code.likes.find_by(user_id: current_user.id)       : nil),
+      current_bookmark:  (logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id)   : nil) %>
 <% end %>
 
 <%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>

--- a/app/views/pre_codes/_form.html.erb
+++ b/app/views/pre_codes/_form.html.erb
@@ -1,10 +1,21 @@
 <!-- app/views/pre_codes/_form.html.erb -->
 <%= render "shared/errors", object: pre_code %>
 
-<%= form_with model: pre_code, class: "space-y-6" do |f| %>
+<%
+  # 管理側から呼ばれたときだけ admin ネームスペースに送る
+  admin_namespace = (local_assigns[:namespace] == :admin)
+  form_model      = admin_namespace ? [:admin, pre_code] : pre_code
+%>
+
+<%= form_with model: form_model, class: "space-y-6" do |f| %>
   <div data-controller="precode-mode"
        data-precode-mode-mode-value="normal"
        class="space-y-6">
+
+    <!-- モードの現在値を送る hidden -->
+    <%= f.hidden_field :quiz_mode,
+          value: "false",
+          data: { "precode-mode-target": "modeField" } %>
 
     <div class="flex items-center justify-end">
       <button type="button"
@@ -27,7 +38,7 @@
     <!-- タグ -->
     <div class="space-y-2">
       <label class="block text-sm font-semibold text-slate-500">タグ（最大10個）</label>
-      <input id="tag-input" name="tag_names" value="<%= @pre_code.tags.map(&:name).join(',') %>"
+      <input id="tag-input" name="tag_names" value="<%= pre_code.tags.map(&:name).join(',') %>"
              class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2"
              placeholder="例: ruby, array, sql"
              data-controller="tag-token"
@@ -35,13 +46,18 @@
       <div id="tag-suggest" class="text-sm text-slate-500"></div>
     </div>
 
-    <!-- 説明 -->
+    <!-- 説明（通常モードの“問題文”相当） -->
     <div class="space-y-2">
       <label class="block text-sm font-semibold text-slate-500"
              data-precode-mode-target="descLabel">コードの説明</label>
       <%= f.text_area :description, rows: 3,
             placeholder: "コード内容の説明を簡単に書いてください",
-            class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
+            class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2",
+            data: {
+              controller: "autosize",
+              "autosize-target": "field",
+              "autosize-min-rows-value": 3
+            } %>
     </div>
 
     <!-- ▼ ヒント（問題モード時のみ表示） -->
@@ -49,7 +65,12 @@
       <label class="block text-sm font-semibold text-slate-500">ヒント（任意）</label>
       <%= f.text_area :hint, rows: 3,
             placeholder: "ヒント本文（1000文字まで）",
-            class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
+            class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2",
+            data: {
+              controller: "autosize",
+              "autosize-target": "field",
+              "autosize-min-rows-value": 3
+            } %>
     </div>
 
     <!-- ▼ 登録コード（常に表示） -->
@@ -69,7 +90,12 @@
       <%= f.text_area :answer, rows: 4,
             placeholder: "解答本文（2000文字まで）",
             class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2",
-            data: { "precode-mode-target": "answerField" } %>
+            data: {
+              controller: "autosize",
+              "autosize-target": "field",
+              "autosize-min-rows-value": 4,
+              "precode-mode-target": "answerField"
+            } %>
 
       <div class="space-y-2">
         <label class="block text-sm font-semibold text-slate-500">解答用コード（任意）</label>

--- a/spec/models/pre_code_quiz_spec.rb
+++ b/spec/models/pre_code_quiz_spec.rb
@@ -2,26 +2,36 @@
 require "rails_helper"
 
 RSpec.describe PreCode, type: :model do
-  it "answer が必須" do
+  it "quiz_mode: true では answer が必須" do
     pc = build(:pre_code, answer: nil)
+    pc.quiz_mode = true
     expect(pc).to be_invalid
     expect(pc.errors[:answer]).to be_present
   end
 
+  it "quiz_mode: false なら answer は空でも可" do
+    pc = build(:pre_code, answer: nil)
+    pc.quiz_mode = false
+    expect(pc).to be_valid
+  end
+
   it "hint は 1000 文字以内" do
     pc = build(:pre_code, hint: "あ" * 1001, answer: "OK")
+    pc.quiz_mode = true
     expect(pc).to be_invalid
     expect(pc.errors[:hint]).to be_present
   end
 
   it "answer は 2000 文字以内" do
     pc = build(:pre_code, answer: "あ" * 2001)
+    pc.quiz_mode = true
     expect(pc).to be_invalid
     expect(pc.errors[:answer]).to be_present
   end
 
   it "有効な値なら保存できる" do
     pc = build(:pre_code, hint: "ヒント", answer: "解答")
+    pc.quiz_mode = true
     expect(pc).to be_valid
   end
 end

--- a/spec/requests/pre_codes_quiz_spec.rb
+++ b/spec/requests/pre_codes_quiz_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe "PreCodes (Quiz)", type: :request do
   before { sign_in user }
 
   it "解答が空だと 422 で失敗する" do
-    params = attributes_for(:pre_code).merge(answer: nil, hint: "h")
+    params = attributes_for(:pre_code).merge(answer: nil, hint: "h", quiz_mode: true)
     post pre_codes_path, params: { pre_code: params }
     expect(response).to have_http_status(:unprocessable_entity)
   end
 
   it "作成時に hint/answer が保存される" do
-    params = attributes_for(:pre_code).merge(hint: "ヒント", answer: "解答")
+    params = attributes_for(:pre_code).merge(hint: "ヒント", answer: "解答", quiz_mode: true)
     post pre_codes_path, params: { pre_code: params }
     expect(response).to have_http_status(:found)
     pc = PreCode.order(:id).last
@@ -24,19 +24,20 @@ RSpec.describe "PreCodes (Quiz)", type: :request do
   it "保存前にサニタイズされる" do
     params = attributes_for(:pre_code).merge(
       hint:   %(<script>alert(1)</script><b>ok</b>),
-      answer: %(<img src=x onerror=alert(1)>safe)
+      answer: %(<img src=x onerror=alert(1)>safe),
+      quiz_mode: true
     )
     post pre_codes_path, params: { pre_code: params }
     pc = PreCode.order(:id).last
     expect(pc.hint).to include("<b>ok</b>")
     expect(pc.hint).not_to include("<script>")
     expect(pc.answer).to include("safe")
-    expect(pc.answer).not_to include("onerror")
+    expect(pc.answer).not_to include("onerror")  # ← 修正：not.to → not_to
   end
 
   it "更新でも同様に動作する" do
     pc = create(:pre_code, user:, answer: "x")
-    patch pre_code_path(pc), params: { pre_code: { answer: "y", hint: "h2" } }
+    patch pre_code_path(pc), params: { pre_code: { answer: "y", hint: "h2", quiz_mode: true } }
     expect(response).to have_http_status(:found)
     expect(pc.reload.answer).to eq("y")
     expect(pc.reload.hint).to eq("h2")

--- a/spec/requests/pre_codes_spec.rb
+++ b/spec/requests/pre_codes_spec.rb
@@ -66,4 +66,21 @@ RSpec.describe "PreCodes", type: :request do
       expect(response.body).to include('rel="prev"')
     end
   end
+
+  it "通常モード（answer 未送信）でも作成できる" do
+    sign_in(user)
+    params = {
+      pre_code: {
+        title: "Hello!",
+        description: "説明",
+        hint: "",           # 任意
+        body: 'puts "こんにちは"'
+        # answer は送らない（通常モードでは disabled）
+      }
+    }
+    post pre_codes_path, params: params
+    expect(response).to redirect_to(pre_code_path(PreCode.last))
+    follow_redirect!
+    expect(response.body).to include("PreCode を作成しました").or include("Hello!")
+  end
 end


### PR DESCRIPTION
### 概要
本番で発生していた PreCode/管理UI 周りのエラーを横断的に解消し、編集体験と検索性を改善した。

**作業内容**
- PreCode の quiz_mode を仮想属性で受け取り Answer 必須判定を条件化、通常モード未入力エラーを解消（サニタイズも統一）
- Admin::PreCodes を一般側フォーム部品に統合して編集/詳細を問題モード・タグに対応、遷移や保存の不整合を修正
- CodeLibrary のタグ AND 検索を正常化、N+1 回避と並び順（popular/used/newest）を整理
- いいねの Turbo Stream を修正し、ボタン押下でのエラー遷移を解消（actions/metrics 同期更新）
- 入力UIを改善（autosize の再計算連携、長文でも扱いやすい）し、Quill ツールバーを `position: sticky` で画面上部固定
- 主要フローの RSpec を追加（通常/問題モード、サニタイズ、更新、タグ/いいね周り）および RuboCop を適用